### PR TITLE
Mp 2262 bump deps

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,4 @@
 [advisories]
 # Ignore the following advisory IDs.
 # Reported vulnerabilities relate to test-tube which is only used for testing.
-ignore = ["RUSTSEC-2022-0093", "RUSTSEC-2023-0052", "RUSTSEC-2024-0003", "RUSTSEC-2024-0006"]
+ignore = ["RUSTSEC-2024-0003", "RUSTSEC-2024-0006"]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Compile workspace
         run: |
           cargo make build
-          find target/wasm32-unknown-unknown/release -type f ! -name '*.wasm' -deletegit
+          find target/wasm32-unknown-unknown/release -type f ! -name '*.wasm' -delete
 
       - name: Run test coverage
         run: cargo make coverage-lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - main
-      - release/neutron
   pull_request:
 
 env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,17 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tools-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
+        run: |
+          echo "BEFORE CLEAN-UP:"
+          df -h /
+          echo "Cleaning up disk space..."
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/go
+          echo "AFTER CLEAN-UP:"
+          df -h /
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      # install a specific version of Go to satisfy osmosis-test-tube
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.7'
+
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
 
@@ -28,7 +33,7 @@ jobs:
       - name: Compile workspace
         run: |
           cargo make build
-          find target/wasm32-unknown-unknown/release -type f ! -name '*.wasm' -delete
+          find target/wasm32-unknown-unknown/release -type f ! -name '*.wasm' -deletegit
 
       - name: Run test coverage
         run: cargo make coverage-lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,19 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space
+        uses: insightsengineering/disk-space-reclaimer@v1
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tools-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+
       - name: Checkout sources
         uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      # install a specific version of Go to satisfy osmosis-test-tube
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.7'
+
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Format
-        run: cargo make fmt
+        run: cargo make fmt-check
 
       - name: Clippy
         run: cargo make clippy

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      # install a specific version of Go to satisfy osmosis-test-tube
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.7'
+
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
 

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -31,7 +31,7 @@ jobs:
         uses: davidB/rust-cargo-make@v1
 
       - name: Install stable Rust
-        run: cd ../ && cargo make install-stable && cd scripts
+        run: cd ../ && cargo make install-stable-for-scripts && cd scripts
 
       # selecting a toolchain should happen before the plugin, as the cache uses the current rustc version as its cache key
       - name: Cache dependencies

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -26,7 +26,7 @@ jobs:
         uses: davidB/rust-cargo-make@v1
 
       - name: Install stable Rust
-        run: cd ../ && cargo make install-stable-for-scripts && cd scripts
+        run: cd ../ && cargo make install-stable && cd scripts
 
       # selecting a toolchain should happen before the plugin, as the cache uses the current rustc version as its cache key
       - name: Cache dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,16 +51,16 @@ checksum = "423502406a307052f6877030f48b5fb4e9fb338fc5e7c8ca1064210def52876b"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
- "cw20 1.1.1",
+ "cw20 1.1.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "apollo-cw-multi-test"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b88d6037608a781a95ab1125941e2358c37272dcf0d4613de795b81b6ffbf3"
+checksum = "f79f4204575175473a9b7fff8083596d09e6edb07469d2a4176846b353b2d1ef"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -69,7 +69,7 @@ dependencies = [
  "derivative",
  "itertools 0.10.5",
  "k256 0.11.6",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "prost 0.9.0",
  "regex",
  "schemars",
@@ -86,7 +86,7 @@ dependencies = [
  "apollo-cw-asset",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw20 1.1.1",
+ "cw20 1.1.2",
  "regex",
 ]
 
@@ -118,13 +118,14 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "3.6.1"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195a7441515817c0d114ec3bebe9faa21393781f796c179c38c75e3cfb9fb4ec"
+checksum = "c001a7f97db88ffe6fc6cca97bbdbfe926e55599184921ff7e72cd47559440de"
 dependencies = [
  "astroport-circular-buffer",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-asset",
  "cw-storage-plus 0.15.1",
  "cw-utils 1.0.3",
  "cw20 0.15.1",
@@ -193,15 +194,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "astroport-liquidity-manager"
-version = "1.0.3"
+name = "astroport-incentives"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5673fe63b0284e30d1b456dea067cfaa82d2be6eafe5468cc0442917d49a04"
+checksum = "ba05c27479d2885ba313086aa0b7d09284f1393f1ebb6d385f96d93b3c6fb72a"
 dependencies = [
- "astroport 3.6.1",
+ "astroport 3.11.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "cw20 1.1.2",
+ "itertools 0.11.0",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-liquidity-manager"
+version = "1.0.3-astroport-v2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4bf7689e7c37cfecc200aab3401c1ff6a507cccc9fb1baadfa71a73addaa2f"
+dependencies = [
+ "astroport 2.9.0",
  "astroport-factory",
  "astroport-pair",
- "astroport-pair-stable 3.3.0",
+ "astroport-pair-stable",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -243,15 +261,14 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair"
-version = "1.5.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd96bc64722440636ed6267a6945ccce076231a08467d6d46a4af4c4ff062c69"
+checksum = "e760b91eaf269bb2843b75b34eb73d474374bd2ebefbbe3cdb0a58d69959573b"
 dependencies = [
- "astroport 3.6.1",
+ "astroport 2.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.3",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "integer-sqrt",
@@ -261,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-concentrated"
-version = "1.2.13"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a25c6ccbeccd25d36706621db915b67ca5d919e192fb06d7dd35cf69152d84"
+checksum = "04a90ce51403c81af3acf8e7028bb0eb095fce802365453b7e4a13bc0eb0d6d7"
 dependencies = [
  "astroport 2.9.0",
  "astroport-factory",
@@ -279,29 +296,11 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-stable"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a262f2b6916e2a83808b246ff16cb2306a416e88b15a47ddbea5f8b666b1a4"
+checksum = "d052966163fc2dd3eb46ae3c948ee7032a28726e046bc44431f9b488cb1dba90"
 dependencies = [
  "astroport 2.9.0",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 1.0.3",
- "cw2 0.15.1",
- "cw20 0.15.1",
- "itertools 0.10.5",
- "thiserror",
-]
-
-[[package]]
-name = "astroport-pair-stable"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ac52657fa25194936d5218a258c2c041df00f0647e954a23f35e99b730f92b"
-dependencies = [
- "astroport 3.6.1",
- "astroport-circular-buffer",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -401,17 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,38 +458,36 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.50",
  "which",
 ]
 
 [[package]]
 name = "bip32"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30ed1d6f8437a487a266c8293aeb95b61a23261273e3e02912cdb8b68bf798b"
+checksum = "7e141fb0f8be1c7b45887af94c88b182472b57c96b56773250ae00cd6a14a164"
 dependencies = [
  "bs58",
  "hmac",
- "k256 0.11.6",
- "once_cell",
- "pbkdf2",
+ "k256 0.13.1",
  "rand_core 0.6.4",
  "ripemd",
  "sha2 0.10.8",
@@ -607,11 +593,11 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.9.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -680,30 +666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,41 +718,30 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b42021d8488665b1a0d9748f1f81df7235362d194f44481e2e61bf376b77b4"
-dependencies = [
- "prost 0.11.9",
- "prost-types 0.11.9",
- "tendermint-proto 0.23.9",
-]
-
-[[package]]
-name = "cosmos-sdk-proto"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32560304ab4c365791fd307282f76637213d8083c1a98490c35159cd67852237"
 dependencies = [
  "prost 0.12.3",
  "prost-types 0.12.3",
- "tendermint-proto 0.34.1",
+ "tendermint-proto",
 ]
 
 [[package]]
 name = "cosmrs"
-version = "0.9.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3903590099dcf1ea580d9353034c9ba1dbf55d1389a5bd2ade98535c3445d1f9"
+checksum = "47126f5364df9387b9d8559dcef62e99010e1d4098f39eb3f7ee4b5c254e40ea"
 dependencies = [
  "bip32",
- "cosmos-sdk-proto 0.14.0",
- "ecdsa 0.14.8",
+ "cosmos-sdk-proto",
+ "ecdsa 0.16.8",
  "eyre",
- "getrandom",
- "k256 0.11.6",
+ "k256 0.13.1",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "signature 2.1.0",
  "subtle-encoding",
  "tendermint",
  "tendermint-rpc",
@@ -926,15 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,12 +890,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "cw-address-like"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451a4691083a88a3c0630a8a88799e9d4cd6679b7ce8ff22b8da2873ff31d380"
 dependencies = [
  "cosmwasm-std",
+]
+
+[[package]]
+name = "cw-asset"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c999a12f8cd8736f6f86e9a4ede5905530cb23cfdef946b9da1c506ad1b70799"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-address-like",
+ "cw-storage-plus 1.2.0",
+ "cw20 1.1.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -968,28 +937,30 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
- "cw20 1.1.1",
+ "cw20 1.1.2",
  "osmosis-std 0.16.2",
  "thiserror",
 ]
 
 [[package]]
 name = "cw-it"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f452b759fc448ec05d20dc70f25dda8b83ba0a7c994049d27556fd1813a5ad0d"
+checksum = "e1bd88c423ae22eefe99b1b008c8b2d7936def56cfb0c65f6ccf634a0988d7b0"
 dependencies = [
  "anyhow",
  "apollo-cw-multi-test",
  "astroport 2.9.0",
+ "astroport 3.11.1",
  "astroport-factory",
  "astroport-generator",
+ "astroport-incentives",
  "astroport-liquidity-manager",
  "astroport-maker",
  "astroport-native-coin-registry",
  "astroport-pair",
  "astroport-pair-concentrated",
- "astroport-pair-stable 2.1.2",
+ "astroport-pair-stable",
  "astroport-router",
  "astroport-staking",
  "astroport-token",
@@ -1000,13 +971,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw20 0.15.1",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "osmosis-test-tube",
  "paste",
- "prost 0.11.9",
+ "prost 0.12.3",
  "regex",
  "serde",
- "serde_json",
  "strum 0.24.1",
  "test-tube",
  "thiserror",
@@ -1257,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786e9da5e937f473cecd2463e81384c1af65d0f6398bbd851be7655487c55492"
+checksum = "526e39bb20534e25a1cd0386727f0038f4da294e5e535729ba3ef54055246abd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1295,7 +1265,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils 1.0.3",
- "cw20 1.1.1",
+ "cw20 1.1.2",
  "schemars",
  "serde",
  "thiserror",
@@ -1459,21 +1429,23 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "signature 1.6.4",
+ "pkcs8 0.10.2",
+ "signature 2.1.0",
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
+name = "ed25519-consensus"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1539,16 +1511,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "encoding_rs"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1558,7 +1526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1636,7 +1604,6 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1660,32 +1627,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.50",
-]
 
 [[package]]
 name = "futures-sink"
@@ -1705,16 +1650,11 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1826,43 +1766,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1894,7 +1801,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1932,12 +1839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,40 +1863,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-proxy"
-version = "0.9.1"
+name = "hyper-rustls"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
- "bytes",
- "futures",
- "headers",
+ "futures-util",
  "http",
  "hyper",
- "hyper-rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2046,6 +1924,12 @@ checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -2110,7 +1994,6 @@ dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
  "sha2 0.10.8",
- "sha3",
 ]
 
 [[package]]
@@ -2125,15 +2008,6 @@ dependencies = [
  "once_cell",
  "sha2 0.10.8",
  "signature 2.1.0",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -2293,7 +2167,7 @@ dependencies = [
  "mars-testing",
  "mars-types",
  "mars-utils 2.0.0",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "test-case",
  "thiserror",
 ]
@@ -2318,7 +2192,7 @@ dependencies = [
  "mars-testing",
  "mars-types",
  "mars-utils 2.0.0",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "osmosis-test-tube",
  "serde",
 ]
@@ -2449,7 +2323,7 @@ dependencies = [
  "mars-testing",
  "mars-types",
  "mars-utils 2.0.0",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "pyth-sdk-cw",
  "schemars",
  "serde",
@@ -2480,8 +2354,8 @@ name = "mars-osmosis"
 version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
- "osmosis-std 0.19.2",
- "prost 0.11.9",
+ "osmosis-std 0.22.0",
+ "prost 0.12.3",
  "serde",
 ]
 
@@ -2618,7 +2492,7 @@ dependencies = [
  "mars-testing",
  "mars-types",
  "mars-utils 2.0.0",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "serde",
 ]
 
@@ -2740,7 +2614,7 @@ dependencies = [
  "mars-swapper-base",
  "mars-testing",
  "mars-types",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
 ]
 
 [[package]]
@@ -2766,8 +2640,8 @@ dependencies = [
  "mars-rewards-collector-osmosis",
  "mars-swapper-astroport",
  "mars-types",
- "osmosis-std 0.19.2",
- "prost 0.11.9",
+ "osmosis-std 0.22.0",
+ "prost 0.12.3",
  "pyth-sdk-cw",
 ]
 
@@ -2786,7 +2660,7 @@ dependencies = [
  "mars-osmosis",
  "mars-owner 2.0.0",
  "mars-utils 2.0.0",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -2862,7 +2736,7 @@ dependencies = [
  "cw2 1.1.2",
  "mars-types",
  "mars-zapper-base",
- "osmosis-std 0.19.2",
+ "osmosis-std 0.22.0",
  "osmosis-test-tube",
 ]
 
@@ -2901,7 +2775,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2911,7 +2785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f60e477bd71007d9ff78ae020ec1c6b3b47798578af6151429434d86472efc"
 dependencies = [
  "bech32",
- "cosmos-sdk-proto 0.20.0",
+ "cosmos-sdk-proto",
  "cosmwasm-schema",
  "cosmwasm-std",
  "prost 0.12.3",
@@ -2921,7 +2795,7 @@ dependencies = [
  "serde",
  "serde-json-wasm 1.0.1",
  "speedate",
- "tendermint-proto 0.34.1",
+ "tendermint-proto",
  "thiserror",
 ]
 
@@ -2962,7 +2836,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3013,12 +2887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-
-[[package]]
 name = "osmosis-std"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,7 +2894,7 @@ checksum = "75895e4db1a81ca29118e366365744f64314938327e4eedba8e6e462fb15e94f"
 dependencies = [
  "chrono",
  "cosmwasm-std",
- "osmosis-std-derive",
+ "osmosis-std-derive 0.16.2",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "schemars",
@@ -3036,15 +2904,15 @@ dependencies = [
 
 [[package]]
 name = "osmosis-std"
-version = "0.19.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798fade51443a0e07eb25b59a11b320b9e8f03e6e8fbe14c520258f04742fe13"
+checksum = "8641c376f01f5af329dc2a34e4f5527eaeb0bde18cda8d86fed958d04c86159c"
 dependencies = [
  "chrono",
  "cosmwasm-std",
- "osmosis-std-derive",
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "osmosis-std-derive 0.20.1",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "schemars",
  "serde",
  "serde-cw-value",
@@ -3064,17 +2932,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "osmosis-test-tube"
-version = "19.2.0"
+name = "osmosis-std-derive"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dde0a21f1323e7c78f46da4bd0b24149d26483785fb5b39f74016f3f524aad"
+checksum = "c5ebdfd1bc8ed04db596e110c6baa9b174b04f6ed1ec22c666ddc5cb3fa91bd7"
 dependencies = [
- "base64 0.13.1",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "prost-types 0.11.9",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "osmosis-test-tube"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a082b97136d15470a37aa758f227c865594590b69d74721248ed5adf59bf1ca2"
+dependencies = [
+ "base64 0.21.7",
  "bindgen",
  "cosmrs",
  "cosmwasm-std",
- "osmosis-std 0.19.2",
- "prost 0.11.9",
+ "osmosis-std 0.22.0",
+ "prost 0.12.3",
  "serde",
  "serde_json",
  "test-tube",
@@ -3094,25 +2975,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "peg"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
+checksum = "400bcab7d219c38abf8bd7cc2054eb9bbbd4312d66f6a5557d572a203f646f61"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -3120,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
+checksum = "46e61cce859b76d19090f62da50a9fe92bab7c2a5f09e183763559a2ac392c90"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -3131,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
+checksum = "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
 
 [[package]]
 name = "percent-encoding"
@@ -3243,6 +3109,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.50",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3552,6 +3428,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
 
 [[package]]
+name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,17 +3491,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3594,17 +3511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "ripemd160"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -3650,32 +3556,50 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
- "base64 0.13.1",
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3717,7 +3641,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3746,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -3912,14 +3836,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3944,16 +3869,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
 ]
 
 [[package]]
@@ -4029,7 +3944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4044,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -4073,12 +3988,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -4162,6 +4071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,6 +4099,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,45 +4135,45 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tendermint"
-version = "0.23.9"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467f82178deeebcd357e1273a0c0b77b9a8a0313ef7c07074baebe99d87851f4"
+checksum = "15ab8f0a25d0d2ad49ac615da054d6a76aa6603ff95f7d18bafdd34450a1a04b"
 dependencies = [
- "async-trait",
  "bytes",
+ "digest 0.10.7",
  "ed25519",
- "ed25519-dalek",
+ "ed25519-consensus",
  "flex-error",
  "futures",
- "k256 0.11.6",
+ "k256 0.13.1",
  "num-traits",
  "once_cell",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "ripemd160",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "ripemd",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.9.9",
- "signature 1.6.4",
+ "sha2 0.10.8",
+ "signature 2.1.0",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.23.9",
+ "tendermint-proto",
  "time",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.23.9"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42ee0abc27ef5fc34080cce8d43c189950d331631546e7dfb983b6274fa327"
+checksum = "e1a02da769166e2052cd537b1a97c78017632c2d9e19266367b27e73910434fc"
 dependencies = [
  "flex-error",
  "serde",
@@ -4239,24 +4181,6 @@ dependencies = [
  "tendermint",
  "toml",
  "url",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.23.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ce80bf536476db81ecc9ebab834dc329c9c1509a694f211a73858814bfe023"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time",
 ]
 
 [[package]]
@@ -4279,28 +4203,28 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.23.9"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f14aafe3528a0f75e9f3f410b525617b2de16c4b7830a21f717eee62882ec60"
+checksum = "71afae8bb5f6b14ed48d4e1316a643b6c2c3cbad114f510be77b4ed20b7b3e42"
 dependencies = [
  "async-trait",
  "bytes",
  "flex-error",
  "futures",
  "getrandom",
- "http",
- "hyper",
- "hyper-proxy",
- "hyper-rustls",
  "peg",
  "pin-project",
+ "rand",
+ "reqwest",
+ "semver",
  "serde",
  "serde_bytes",
  "serde_json",
+ "subtle",
  "subtle-encoding",
  "tendermint",
  "tendermint-config",
- "tendermint-proto 0.23.9",
+ "tendermint-proto",
  "thiserror",
  "time",
  "tokio",
@@ -4308,15 +4232,6 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -4356,25 +4271,19 @@ dependencies = [
 
 [[package]]
 name = "test-tube"
-version = "0.1.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04de0d85f2438f0b64a5c135a1524564f2b89263cfbce011542446b6681d006f"
+checksum = "09184c7655b2bdaf4517b06141a2e4c44360904f2706a05b24c831bd97ad1db6"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.7",
  "cosmrs",
  "cosmwasm-std",
- "osmosis-std 0.19.2",
- "prost 0.11.9",
+ "osmosis-std 0.22.0",
+ "prost 0.12.3",
  "serde",
  "serde_json",
  "thiserror",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -4442,7 +4351,7 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4458,13 +4367,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -4600,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4617,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "version_check"
@@ -4687,6 +4595,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,25 +4643,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -4793,7 +4694,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -4802,13 +4712,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -4818,10 +4743,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4830,10 +4767,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4842,16 +4791,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "cw-vault-standard"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908934004eb811c72acd4d2d4f6d936695a7e9236815c01c4b6ce3f47c29d272"
+checksum = "9e70a60d4a86860d6b51908201339530c47ef7bfc4fb137f9f9f54468124d35d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2112,7 +2112,7 @@ dependencies = [
  "cw-paginate",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
- "cw-vault-standard 0.3.3",
+ "cw-vault-standard 0.4.0",
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
@@ -2288,7 +2288,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
- "cw-vault-standard 0.3.3",
+ "cw-vault-standard 0.4.0",
  "mars-types",
  "thiserror",
 ]
@@ -2527,7 +2527,7 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
- "cw-vault-standard 0.3.3",
+ "cw-vault-standard 0.4.0",
  "cw2 1.1.2",
  "mars-mock-credit-manager",
  "mars-mock-oracle",
@@ -2546,7 +2546,7 @@ dependencies = [
  "console_error_panic_hook",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-vault-standard 0.3.3",
+ "cw-vault-standard 0.4.0",
  "mars-types",
  "proptest",
  "schemars",
@@ -2655,7 +2655,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
- "cw-vault-standard 0.3.3",
+ "cw-vault-standard 0.4.0",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "mars-osmosis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "apollo-cw-asset"
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "423502406a307052f6877030f48b5fb4e9fb338fc5e7c8ca1064210def52876b"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "cw20 1.1.1",
  "schemars",
  "serde",
@@ -64,8 +64,8 @@ checksum = "27b88d6037608a781a95ab1125941e2358c37272dcf0d4613de795b81b6ffbf3"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "derivative",
  "itertools 0.10.5",
  "k256 0.11.6",
@@ -126,7 +126,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "cw20 0.15.1",
  "cw3",
  "itertools 0.10.5",
@@ -204,7 +204,7 @@ dependencies = [
  "astroport-pair-stable 3.3.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "cw20 0.15.1",
  "cw20-base",
  "thiserror",
@@ -251,7 +251,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "integer-sqrt",
@@ -287,7 +287,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "itertools 0.10.5",
@@ -305,7 +305,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "itertools 0.10.5",
@@ -397,7 +397,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "borsh"
@@ -761,19 +761,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20b42021d8488665b1a0d9748f1f81df7235362d194f44481e2e61bf376b77b4"
 dependencies = [
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "tendermint-proto 0.23.9",
 ]
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.16.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4776e787b24d9568dd61d3237eeb4eb321d622fb881b858c7b82806420e87d4"
+checksum = "32560304ab4c365791fd307282f76637213d8083c1a98490c35159cd67852237"
 dependencies = [
- "prost 0.11.9",
- "prost-types",
- "tendermint-proto 0.27.0",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "tendermint-proto 0.34.1",
 ]
 
 [[package]]
@@ -799,11 +799,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.4.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fb22494cf7d23d0c348740e06e5c742070b2991fd41db77bba0bcfbae1a723"
+checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa 0.16.8",
  "ed25519-zebra",
  "k256 0.13.1",
  "rand_core 0.6.4",
@@ -812,18 +813,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.4.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e199424486ea97d6b211db6387fd72e26b4a439d40cc23140b2d8305728055b"
+checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.4.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef683a9c1c4eabd6d31515719d0d2cc66952c4c87f7eb192bfc90384517dc34"
+checksum = "ac3e3a2136e2a60e8b6582f5dffca5d1a683ed77bf38537d330bc1dfccd69010"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -834,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.4.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9567025acbb4c0c008178393eb53b3ac3c2e492c25949d3bf415b9cbe80772d8"
+checksum = "f5d803bea6bd9ed61bd1ee0b4a2eb09ee20dbb539cc6e0b8795614d20952ebb1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -845,11 +846,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.4.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d89d680fb60439b7c5947b15f9c84b961b88d1f8a3b20c4bd178a3f87db8bae"
+checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
 dependencies = [
  "base64 0.21.7",
+ "bech32",
  "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
@@ -858,8 +860,9 @@ dependencies = [
  "hex",
  "schemars",
  "serde",
- "serde-json-wasm 0.5.1",
+ "serde-json-wasm 0.5.2",
  "sha2 0.10.8",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -963,8 +966,8 @@ dependencies = [
  "apollo-utils",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "cw20 1.1.1",
  "osmosis-std 0.16.2",
  "thiserror",
@@ -1017,11 +1020,11 @@ checksum = "6d818f5323c80ed4890db7f89d65eda3f0261fe21878e628c27ea2d8de4b7ba4"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "derivative",
  "itertools 0.11.0",
- "prost 0.12.1",
+ "prost 0.12.3",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -1038,8 +1041,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-address-like",
  "cw-ownable-derive",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "thiserror",
 ]
 
@@ -1061,7 +1064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add278617f6251be1a35c781eb0fbffd44f899d8bb4dc5a9e420273a90684c4e"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "serde",
 ]
 
@@ -1089,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
+checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -1130,13 +1133,13 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9f351a4e4d81ef7c890e44d903f8c0bdcdc00f094fd3a181eaf70c0eec7a3a"
+checksum = "1c4a657e5caacc3a0d00ee96ca8618745d050b8f757c709babafb81208d4239c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.1.1",
+ "cw2 1.1.2",
  "schemars",
  "semver",
  "serde",
@@ -1151,7 +1154,7 @@ checksum = "793cd7de3239b1bf187a2a61c8e37d80bb9bd6e354328bfb12070323a435eee1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "schemars",
  "serde",
 ]
@@ -1164,7 +1167,7 @@ checksum = "908934004eb811c72acd4d2d4f6d936695a7e9236815c01c4b6ce3f47c29d272"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "schemars",
  "serde",
 ]
@@ -1226,14 +1229,15 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9431d14f64f49e41c6ef5561ed11a5391c417d0cb16455dea8cdcb9037a8d197"
+checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
@@ -1259,7 +1263,7 @@ checksum = "786e9da5e937f473cecd2463e81384c1af65d0f6398bbd851be7655487c55492"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "schemars",
  "serde",
 ]
@@ -1290,7 +1294,7 @@ checksum = "1d056ec33ec146554aa1d16c9535763341db75589a47743c006c377e62b54034"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "cw20 1.1.1",
  "schemars",
  "serde",
@@ -1317,7 +1321,7 @@ source = "git+https://github.com/CosmWasm/cw-nfts/?branch=main#177a993dfb5a1a316
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.2",
+ "cw-utils 1.0.3",
  "schemars",
  "serde",
 ]
@@ -1347,9 +1351,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-ownable",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.16.0",
  "schemars",
@@ -1680,7 +1684,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2001,8 +2005,8 @@ source = "git+https://github.com/Stride-Labs/ica-oracle?rev=2fdf76f#2fdf76f3ba4f
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "hex",
  "sha2 0.10.8",
  "thiserror",
@@ -2057,6 +2061,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2183,8 +2196,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.16.0",
  "cw721-base 0.18.0",
@@ -2204,8 +2217,8 @@ dependencies = [
  "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-owner 2.0.0",
  "mars-testing",
  "mars-types",
@@ -2222,13 +2235,13 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-paginate",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "cw-vault-standard 0.3.3",
- "cw2 1.1.1",
+ "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "mars-account-nft",
  "mars-address-provider",
  "mars-liquidation",
@@ -2272,8 +2285,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-owner 2.0.0",
  "mars-red-bank",
  "mars-red-bank-types 1.0.0 (git+https://github.com/mars-protocol/red-bank?tag=v1.0.0)",
@@ -2336,8 +2349,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "mars-types",
  "thiserror",
 ]
@@ -2348,7 +2361,7 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "mars-types",
 ]
 
@@ -2358,7 +2371,7 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "mars-types",
 ]
 
@@ -2377,8 +2390,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "mars-types",
 ]
 
@@ -2388,7 +2401,7 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "mars-types",
 ]
 
@@ -2398,8 +2411,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "cw-vault-standard 0.3.3",
  "mars-types",
  "thiserror",
@@ -2410,8 +2423,8 @@ name = "mars-oracle-base"
 version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-owner 2.0.0",
  "mars-types",
  "mars-utils 2.0.0",
@@ -2427,8 +2440,8 @@ version = "2.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "ica-oracle",
  "mars-oracle-base",
  "mars-osmosis",
@@ -2451,8 +2464,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-it",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-oracle-base",
  "mars-owner 2.0.0",
  "mars-testing",
@@ -2480,7 +2493,7 @@ checksum = "acd53908ffc561da878ce5ff4f5ec9f25a193af28ec0b6e7c8e6d1a0866d9dfc"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "schemars",
  "thiserror",
 ]
@@ -2493,7 +2506,7 @@ checksum = "ab46e0b2f81a8a98036b46730fbe33a337e98e87cb3d34553b45a5ae87c5828c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "schemars",
  "thiserror",
 ]
@@ -2506,8 +2519,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-interest-rate",
  "mars-owner 2.0.0",
  "mars-testing",
@@ -2525,9 +2538,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "mars-health 2.0.0",
  "mars-interest-rate",
  "mars-liquidation",
@@ -2570,8 +2583,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-owner 2.0.0",
  "mars-types",
  "mars-utils 2.0.0",
@@ -2585,7 +2598,7 @@ name = "mars-rewards-collector-neutron"
 version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
- "cw2 1.1.1",
+ "cw2 1.1.2",
  "mars-rewards-collector-base",
  "mars-types",
  "neutron-sdk",
@@ -2597,8 +2610,8 @@ version = "2.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-osmosis",
  "mars-owner 2.0.0",
  "mars-rewards-collector-base",
@@ -2616,8 +2629,8 @@ source = "git+https://github.com/mars-protocol/v2-fields-of-mars?rev=183e4c5#183
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "cw-vault-standard 0.2.0",
  "cw721 0.16.0",
  "cw721-base 0.16.0",
@@ -2637,10 +2650,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "cw-vault-standard 0.3.3",
- "cw2 1.1.1",
+ "cw2 1.1.2",
  "mars-mock-credit-manager",
  "mars-mock-oracle",
  "mars-mock-vault",
@@ -2678,7 +2691,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-it",
- "cw2 1.1.1",
+ "cw2 1.1.2",
  "mars-oracle-wasm",
  "mars-swapper-base",
  "mars-testing",
@@ -2693,8 +2706,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-paginate",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-owner 2.0.0",
  "mars-types",
  "schemars",
@@ -2720,8 +2733,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-it",
- "cw-storage-plus 1.1.0",
- "cw2 1.1.1",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
  "mars-osmosis",
  "mars-owner 2.0.0",
  "mars-swapper-base",
@@ -2765,8 +2778,8 @@ dependencies = [
  "astroport 2.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "cw-vault-standard 0.3.3",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
@@ -2776,8 +2789,8 @@ dependencies = [
  "osmosis-std 0.19.2",
  "schemars",
  "serde",
- "serde-json-wasm 1.0.0",
- "strum 0.25.0",
+ "serde-json-wasm 1.0.1",
+ "strum 0.26.1",
  "thiserror",
  "tsify",
  "wasm-bindgen",
@@ -2808,7 +2821,7 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "thiserror",
 ]
 
@@ -2819,8 +2832,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-dex",
- "cw-utils 1.0.2",
- "cw2 1.1.1",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "mars-types",
  "schemars",
  "serde",
@@ -2833,8 +2846,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "cw-utils 1.0.2",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
  "mars-types",
  "thiserror",
 ]
@@ -2845,8 +2858,8 @@ version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
  "cw-dex",
- "cw-utils 1.0.2",
- "cw2 1.1.1",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "mars-types",
  "mars-zapper-base",
  "osmosis-std 0.19.2",
@@ -2893,21 +2906,22 @@ dependencies = [
 
 [[package]]
 name = "neutron-sdk"
-version = "0.6.1"
-source = "git+https://github.com/neutron-org/neutron-sdk?rev=74fea05#74fea05e407e5ff7cdfc195c3a76d2cce6a47d20"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f60e477bd71007d9ff78ae020ec1c6b3b47798578af6151429434d86472efc"
 dependencies = [
- "base64 0.21.7",
  "bech32",
- "cosmos-sdk-proto 0.16.0",
+ "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
- "prost 0.11.9",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "protobuf 3.3.0",
  "schemars",
  "serde",
- "serde-json-wasm 0.5.1",
- "serde_json",
+ "serde-json-wasm 1.0.1",
+ "speedate",
+ "tendermint-proto 0.34.1",
  "thiserror",
 ]
 
@@ -3014,7 +3028,7 @@ dependencies = [
  "cosmwasm-std",
  "osmosis-std-derive",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "schemars",
  "serde",
  "serde-cw-value",
@@ -3030,7 +3044,7 @@ dependencies = [
  "cosmwasm-std",
  "osmosis-std-derive",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "schemars",
  "serde",
  "serde-cw-value",
@@ -3044,7 +3058,7 @@ checksum = "f47f0b2f22adb341bb59e5a3a1b464dde033181954bd055b9ae86d6511ba465b"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
- "prost-types",
+ "prost-types 0.11.9",
  "quote",
  "syn 1.0.109",
 ]
@@ -3158,7 +3172,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3189,7 +3203,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3265,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -3314,12 +3328,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.1",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -3350,15 +3364,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3368,6 +3382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -3385,7 +3408,6 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b65f4a8ec18723a734e5dc09c173e0abf9690432da5340285d536edcb4dac190"
 dependencies = [
- "bytes",
  "once_cell",
  "protobuf-support",
  "thiserror",
@@ -3433,9 +3455,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -3700,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3712,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3791,9 +3813,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -3809,18 +3831,18 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde-json-wasm"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c37d03f3b0f6b5f77c11af1e7c772de1c9af83e50bef7bb6069601900ba67b"
+checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
 dependencies = [
  "serde",
 ]
@@ -3836,13 +3858,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3864,14 +3886,14 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -3886,7 +3908,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4011,6 +4033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "speedate"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242f76c50fd18cbf098607090ade73a08d39cfd84ea835f3796a2c855223b19b"
+dependencies = [
+ "strum 0.25.0",
+ "strum_macros 0.25.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,6 +4099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+dependencies = [
+ "strum_macros 0.26.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,7 +4130,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.38",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4120,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4158,7 +4212,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "ripemd160",
  "serde",
  "serde_bytes",
@@ -4198,7 +4252,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -4207,16 +4261,16 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.27.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5895470f28c530f8ae8c4071bf8190304ce00bd131d25e81730453124a3375c"
+checksum = "b797dd3d2beaaee91d2f065e7bdf239dc8d80bba4a183a288bc1279dd5a69a1e"
 dependencies = [
  "bytes",
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.11.9",
- "prost-types",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -4284,7 +4338,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4296,7 +4350,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
  "test-case-core",
 ]
 
@@ -4324,22 +4378,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4399,7 +4453,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4490,7 +4544,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals 0.28.0",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4609,9 +4663,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4619,24 +4673,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4644,22 +4698,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
@@ -4825,5 +4879,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.50",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,16 +984,17 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d818f5323c80ed4890db7f89d65eda3f0261fe21878e628c27ea2d8de4b7ba4"
+checksum = "67fff029689ae89127cf6d7655809a68d712f3edbdb9686c70b018ba438b26ca"
 dependencies = [
  "anyhow",
+ "bech32",
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "derivative",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "prost 0.12.3",
  "schemars",
  "serde",
@@ -3164,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -3176,7 +3177,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.7.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3401,7 +3402,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.0",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3412,14 +3413,8 @@ checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.0",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -4236,9 +4231,9 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "3.2.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f1e820b7f1d95a0cdbf97a5df9de10e1be731983ab943e56703ac1b8e9d425"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
 dependencies = [
  "test-case-macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,8 @@ ica-oracle         = { git = "https://github.com/Stride-Labs/ica-oracle", rev = 
 itertools          = "0.12.1"
 mars-owner         = { version = "2.0.0", features = ["emergency-owner"] }
 neutron-sdk        = "0.8.0"
-# TODO
-osmosis-std        = "0.19.2"
-# TODO
-prost              = { version = "0.11.9", default-features = false }
+osmosis-std        = "0.22.0"
+prost              = { version = "0.12.3", default-features = false }
 pyth-sdk-cw        = "1.2.0"
 schemars           = "0.8.16"
 serde              = { version = "1.0.197", default-features = false }
@@ -90,8 +88,8 @@ wasm-bindgen       = "0.2.91"
 
 # dev-dependencies
 cw-multi-test     = "0.17.0"
-cw-it             = "0.2.3"
-osmosis-test-tube = "19.2.0"
+cw-it             = "0.3.0"
+osmosis-test-tube = "22.1.0"
 proptest          = "1.2.0"
 test-case         = "3.2.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,37 +54,39 @@ documentation = "https://docs.marsprotocol.io/"
 keywords      = ["mars", "cosmos", "cosmwasm"]
 
 [workspace.dependencies]
-anyhow             = "1.0.75"
+anyhow             = "1.0.80"
 astroport          = "2.8.0"
 bech32             = "0.9.1"
-cosmwasm-schema    = "1.4.0"
-cosmwasm-std       = "1.4.0"
-cw2                = "1.1.0"
+cosmwasm-schema    = "1.5.3"
+cosmwasm-std       = "1.5.3"
+cw2                = "1.1.2"
 cw721              = { git = "https://github.com/CosmWasm/cw-nfts/", branch = "main" }
 cw721-base         = { git = "https://github.com/CosmWasm/cw-nfts/", branch = "main", features = ["library"] }
+# TODO
 cw-dex             = { version = "0.3.1", features = ["osmosis"] }
 cw-paginate        = "0.2.1"
-cw-storage-plus    = "1.1.0"
-cw-utils           = "1.0.1"
+cw-storage-plus    = "1.2.0"
+cw-utils           = "1.0.3"
+# TODO
 cw-vault-standard  = { version = "0.3.1", features = ["lockup", "force-unlock"] }
 ica-oracle         = { git = "https://github.com/Stride-Labs/ica-oracle", rev = "2fdf76f", features = ["library"] }
-itertools          = "0.11.0"
+itertools          = "0.12.1"
 mars-owner         = { version = "2.0.0", features = ["emergency-owner"] }
-# Use the latest Github main branch which includes a fix related to protobuf versioning:
-# https://github.com/neutron-org/neutron-sdk/commit/ef6351974099bf0d301edf2c689f0c920958331a
-neutron-sdk        = { git = "https://github.com/neutron-org/neutron-sdk", rev = "74fea05" }
+neutron-sdk        = "0.8.0"
+# TODO
 osmosis-std        = "0.19.2"
+# TODO
 prost              = { version = "0.11.9", default-features = false }
 pyth-sdk-cw        = "1.2.0"
-schemars           = "0.8.12"
-serde              = { version = "1.0.188", default-features = false }
-serde_json         = "1.0.103"
-serde-json-wasm    = "1.0.0"
-serde-wasm-bindgen = "0.5.0"
-strum              = "0.25.0"
-thiserror          = "1.0.48"
+schemars           = "0.8.16"
+serde              = { version = "1.0.197", default-features = false }
+serde_json         = "1.0.114"
+serde-json-wasm    = "1.0.1"
+serde-wasm-bindgen = "0.6.4"
+strum              = "0.26.1"
+thiserror          = "1.0.57"
 tsify              = "0.4.5"
-wasm-bindgen       = "0.2.87"
+wasm-bindgen       = "0.2.91"
 
 # dev-dependencies
 cw-multi-test     = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,11 @@ cosmwasm-std       = "1.5.3"
 cw2                = "1.1.2"
 cw721              = { git = "https://github.com/CosmWasm/cw-nfts/", branch = "main" }
 cw721-base         = { git = "https://github.com/CosmWasm/cw-nfts/", branch = "main", features = ["library"] }
-# TODO
 cw-dex             = { version = "0.3.1", features = ["osmosis"] }
 cw-paginate        = "0.2.1"
 cw-storage-plus    = "1.2.0"
 cw-utils           = "1.0.3"
-# TODO
-cw-vault-standard  = { version = "0.3.1", features = ["lockup", "force-unlock"] }
+cw-vault-standard  = { version = "0.4.0", features = ["lockup", "force-unlock"] }
 ica-oracle         = { git = "https://github.com/Stride-Labs/ica-oracle", rev = "2fdf76f", features = ["library"] }
 itertools          = "0.12.1"
 mars-owner         = { version = "2.0.0", features = ["emergency-owner"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,11 +87,11 @@ tsify              = "0.4.5"
 wasm-bindgen       = "0.2.91"
 
 # dev-dependencies
-cw-multi-test     = "0.17.0"
+cw-multi-test     = "0.20.0"
 cw-it             = "0.3.0"
 osmosis-test-tube = "22.1.0"
-proptest          = "1.2.0"
-test-case         = "3.2.1"
+proptest          = "1.4.0"
+test-case         = "3.3.1"
 
 # packages
 mars-health                = { path = "./packages/health" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -24,6 +24,10 @@ rustup component add clippy --toolchain ${RUST_VERSION}
 rustup component add llvm-tools-preview --toolchain ${RUST_VERSION}
 '''
 
+[tasks.install-stable-for-scripts]
+env = { RUST_VERSION = "1.76.0" }
+run_task = "install-stable"
+
 [tasks.install-nightly]
 script = '''
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,7 +13,7 @@ ARTIFACTS_DIR_PATH = "target/wasm32-unknown-unknown/release"
 RUST_OPTIMIZER_VERSION = "0.13.0"
 # Use rust version from rust-optimizer Dockerfile (see https://github.com/CosmWasm/rust-optimizer/blob/main/Dockerfile#L1)
 # to be sure that we compile / test against the same version
-RUST_VERSION = "1.69.0"
+RUST_VERSION = "1.76.0"
 
 [tasks.install-stable]
 script = '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -24,10 +24,6 @@ rustup component add clippy --toolchain ${RUST_VERSION}
 rustup component add llvm-tools-preview --toolchain ${RUST_VERSION}
 '''
 
-[tasks.install-stable-for-scripts]
-env = { RUST_VERSION = "1.72.0" }
-run_task = "install-stable"
-
 [tasks.install-nightly]
 script = '''
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly
@@ -69,6 +65,11 @@ command = "cargo"
 args = ["test", "--locked", "-p", "mars-integration-tests", "-p", "mars-swapper-astroport", "-p", "mars-oracle-wasm", "-p", "mars-swapper-osmosis", "--test", "*"]
 
 [tasks.fmt]
+toolchain = "nightly"
+command = "cargo"
+args = ["fmt", "--all"]
+
+[tasks.fmt-check]
 toolchain = "nightly"
 command = "cargo"
 args = ["fmt", "--all", "--check"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,8 +9,11 @@ default_to_workspace = false
 [env]
 # Directory with wasm files used by integration tests (another directory can be used instead, for example 'artifacts' from rust-optimizer)
 ARTIFACTS_DIR_PATH = "target/wasm32-unknown-unknown/release"
+# If you bump this version, verify RUST_VERSION correctness
 RUST_OPTIMIZER_VERSION = "0.15.0"
-RUST_VERSION = "1.76.0"
+# Use rust version from rust-optimizer Dockerfile (see https://github.com/CosmWasm/rust-optimizer/blob/v0.15.0/Dockerfile#L1)
+# to be sure that we compile / test against the same version
+RUST_VERSION = "1.73.0"
 
 [tasks.install-stable]
 script = '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,10 +9,7 @@ default_to_workspace = false
 [env]
 # Directory with wasm files used by integration tests (another directory can be used instead, for example 'artifacts' from rust-optimizer)
 ARTIFACTS_DIR_PATH = "target/wasm32-unknown-unknown/release"
-# If you bump this version, verify RUST_VERSION correctness
-RUST_OPTIMIZER_VERSION = "0.13.0"
-# Use rust version from rust-optimizer Dockerfile (see https://github.com/CosmWasm/rust-optimizer/blob/main/Dockerfile#L1)
-# to be sure that we compile / test against the same version
+RUST_OPTIMIZER_VERSION = "0.15.0"
 RUST_VERSION = "1.76.0"
 
 [tasks.install-stable]

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Creates JSON schema files for relevant contract calls, queries and query respons
 `rustfmt` is used to format any Rust source code:
 
 ```bash
-cargo +nightly fmt
+cargo make fmt
 ```
 
 `clippy` is used as a linting tool:

--- a/contracts/account-nft/src/contract.rs
+++ b/contracts/account-nft/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+    to_json_binary, Addr, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
 };
 use cw2::set_contract_version;
 use cw721_base::Cw721Contract;
@@ -80,8 +80,8 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::NextId {} => to_binary(&query_next_id(deps)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
+        QueryMsg::NextId {} => to_json_binary(&query_next_id(deps)?),
         _ => Parent::default().query(deps, env, msg.try_into()?),
     }
 }

--- a/contracts/account-nft/src/execute.rs
+++ b/contracts/account-nft/src/execute.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    to_binary, DepsMut, Empty, Env, MessageInfo, QueryRequest, Response, WasmQuery,
+    to_json_binary, DepsMut, Empty, Env, MessageInfo, QueryRequest, Response, WasmQuery,
 };
 use cw721::Cw721Execute;
 use cw721_base::{
@@ -48,7 +48,7 @@ pub fn burn(
 
     let acc_kind: AccountKind = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: cm_contract_addr.into(),
-        msg: to_binary(&QueryMsg::AccountKind {
+        msg: to_json_binary(&QueryMsg::AccountKind {
             account_id: token_id.clone(),
         })?,
     }))?;
@@ -56,7 +56,7 @@ pub fn burn(
     let response: HealthValuesResponse =
         deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: health_contract_addr.into(),
-            msg: to_binary(&HealthValues {
+            msg: to_json_binary(&HealthValues {
                 account_id: token_id.clone(),
                 kind: acc_kind,
                 action: ActionKind::Default,

--- a/contracts/account-nft/src/migrations/v2_0_0.rs
+++ b/contracts/account-nft/src/migrations/v2_0_0.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    to_binary, DepsMut, Empty, QueryRequest, Response, StdError, Storage, WasmQuery,
+    to_json_binary, DepsMut, Empty, QueryRequest, Response, StdError, Storage, WasmQuery,
 };
 use cw2::set_contract_version;
 use cw721::Cw721Query;
@@ -106,7 +106,7 @@ fn burn_empty_account(
     let response: HealthValuesResponse =
         deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: health_contract,
-            msg: to_binary(&HealthValues {
+            msg: to_json_binary(&HealthValues {
                 account_id: token_id.clone(),
                 kind: AccountKind::Default, // all current accounts are default
                 action: ActionKind::Default,

--- a/contracts/address-provider/src/contract.rs
+++ b/contracts/address-provider/src/contract.rs
@@ -3,7 +3,8 @@ use std::convert::TryInto;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response, StdResult,
+    to_json_binary, Addr, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response,
+    StdResult,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
@@ -108,13 +109,15 @@ fn update_owner(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::Address(address_type) => to_binary(&query_address(deps, address_type)?),
-        QueryMsg::Addresses(address_types) => to_binary(&query_addresses(deps, address_types)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
+        QueryMsg::Address(address_type) => to_json_binary(&query_address(deps, address_type)?),
+        QueryMsg::Addresses(address_types) => {
+            to_json_binary(&query_addresses(deps, address_types)?)
+        }
         QueryMsg::AllAddresses {
             start_after,
             limit,
-        } => to_binary(&query_all_addresses(deps, start_after, limit)?),
+        } => to_json_binary(&query_all_addresses(deps, start_after, limit)?),
     }
 }
 

--- a/contracts/address-provider/tests/tests/helpers/mod.rs
+++ b/contracts/address-provider/tests/tests/helpers/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use cosmwasm_std::{
-    from_binary,
+    from_json,
     testing::{
         mock_dependencies_with_balance, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
     },
@@ -28,5 +28,5 @@ pub fn th_setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
 }
 
 pub fn th_query<T: serde::de::DeserializeOwned>(deps: Deps, msg: QueryMsg) -> T {
-    from_binary(&query(deps, mock_env(), msg).unwrap()).unwrap()
+    from_json(query(deps, mock_env(), msg).unwrap()).unwrap()
 }

--- a/contracts/credit-manager/src/claim_rewards.rs
+++ b/contracts/credit-manager/src/claim_rewards.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    to_binary, Addr, BankMsg, Coin, CosmosMsg, DepsMut, Env, QuerierWrapper, Response, StdResult,
-    WasmMsg,
+    to_json_binary, Addr, BankMsg, Coin, CosmosMsg, DepsMut, Env, QuerierWrapper, Response,
+    StdResult, WasmMsg,
 };
 use mars_types::{
     credit_manager::{CallbackMsg, ExecuteMsg},
@@ -61,7 +61,7 @@ fn send_rewards_msg(
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: credit_manager_addr.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::SendRewardsToAddr {
+        msg: to_json_binary(&ExecuteMsg::Callback(CallbackMsg::SendRewardsToAddr {
             account_id: account_id.to_string(),
             previous_balances: coins,
             recipient,

--- a/contracts/credit-manager/src/contract.rs
+++ b/contracts/credit-manager/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
 };
 use cw2::set_contract_version;
 use mars_types::{
@@ -80,46 +80,46 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     let res = match msg {
         QueryMsg::AccountKind {
             account_id,
-        } => to_binary(&get_account_kind(deps.storage, &account_id)?),
+        } => to_json_binary(&get_account_kind(deps.storage, &account_id)?),
         QueryMsg::Accounts {
             owner,
             start_after,
             limit,
-        } => to_binary(&query_accounts(deps, owner, start_after, limit)?),
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        } => to_json_binary(&query_accounts(deps, owner, start_after, limit)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::VaultUtilization {
             vault,
-        } => to_binary(&query_vault_utilization(deps, env, vault)?),
+        } => to_json_binary(&query_vault_utilization(deps, env, vault)?),
         QueryMsg::Positions {
             account_id,
-        } => to_binary(&query_positions(deps, &account_id)?),
+        } => to_json_binary(&query_positions(deps, &account_id)?),
         QueryMsg::AllCoinBalances {
             start_after,
             limit,
-        } => to_binary(&query_all_coin_balances(deps, start_after, limit)?),
+        } => to_json_binary(&query_all_coin_balances(deps, start_after, limit)?),
         QueryMsg::AllDebtShares {
             start_after,
             limit,
-        } => to_binary(&query_all_debt_shares(deps, start_after, limit)?),
-        QueryMsg::TotalDebtShares(denom) => to_binary(&query_total_debt_shares(deps, &denom)?),
+        } => to_json_binary(&query_all_debt_shares(deps, start_after, limit)?),
+        QueryMsg::TotalDebtShares(denom) => to_json_binary(&query_total_debt_shares(deps, &denom)?),
         QueryMsg::AllTotalDebtShares {
             start_after,
             limit,
-        } => to_binary(&query_all_total_debt_shares(deps, start_after, limit)?),
+        } => to_json_binary(&query_all_total_debt_shares(deps, start_after, limit)?),
         QueryMsg::AllVaultPositions {
             start_after,
             limit,
-        } => to_binary(&query_all_vault_positions(deps, start_after, limit)?),
+        } => to_json_binary(&query_all_vault_positions(deps, start_after, limit)?),
         QueryMsg::EstimateProvideLiquidity {
             lp_token_out,
             coins_in,
-        } => to_binary(&estimate_provide_liquidity(deps, &lp_token_out, coins_in)?),
+        } => to_json_binary(&estimate_provide_liquidity(deps, &lp_token_out, coins_in)?),
         QueryMsg::EstimateWithdrawLiquidity {
             lp_token,
-        } => to_binary(&estimate_withdraw_liquidity(deps, lp_token)?),
+        } => to_json_binary(&estimate_withdraw_liquidity(deps, lp_token)?),
         QueryMsg::VaultPositionValue {
             vault_position,
-        } => to_binary(&query_vault_position_value(deps, vault_position)?),
+        } => to_json_binary(&query_vault_position_value(deps, vault_position)?),
     };
     res.map_err(Into::into)
 }

--- a/contracts/credit-manager/src/execute.rs
+++ b/contracts/credit-manager/src/execute.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use cosmwasm_std::{
-    to_binary, Addr, Coins, CosmosMsg, DepsMut, Env, MessageInfo, Response, StdResult, WasmMsg,
+    to_json_binary, Addr, Coins, CosmosMsg, DepsMut, Env, MessageInfo, Response, StdResult, WasmMsg,
 };
 use mars_types::{
     account_nft::ExecuteMsg as NftExecuteMsg,
@@ -49,7 +49,7 @@ pub fn create_credit_account(
     let nft_mint_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: account_nft.address().into(),
         funds: vec![],
-        msg: to_binary(&NftExecuteMsg::Mint {
+        msg: to_json_binary(&NftExecuteMsg::Mint {
             user: user.to_string(),
         })?,
     });

--- a/contracts/credit-manager/src/refund.rs
+++ b/contracts/credit-manager/src/refund.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, DepsMut, Env, Response, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, CosmosMsg, DepsMut, Env, Response, WasmMsg};
 use mars_types::credit_manager::{ActionAmount, ActionCoin, CallbackMsg, ExecuteMsg};
 
 use crate::{error::ContractResult, query::query_coin_balances, utils::query_nft_token_owner};
@@ -17,7 +17,7 @@ pub fn refund_coin_balances(deps: DepsMut, env: Env, account_id: &str) -> Contra
             Ok(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: env.contract.address.to_string(),
                 funds: vec![],
-                msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::Withdraw {
+                msg: to_json_binary(&ExecuteMsg::Callback(CallbackMsg::Withdraw {
                     account_id: account_id.to_string(),
                     coin: action_coin,
                     recipient: Addr::unchecked(account_nft_owner.clone()),

--- a/contracts/credit-manager/src/repay.rs
+++ b/contracts/credit-manager/src/repay.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 
 use cosmwasm_std::{
-    to_binary, BankMsg, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
+    to_json_binary, BankMsg, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
     WasmMsg,
 };
 use cw_utils::one_coin;
@@ -103,7 +103,7 @@ pub fn repay_for_recipient(
     let repay_callback_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: env.contract.address.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(Repay {
+        msg: to_json_binary(&ExecuteMsg::Callback(Repay {
             account_id: recipient_account_id.to_string(),
             coin: ActionCoin::from(coin_to_repay),
         }))?,
@@ -137,7 +137,7 @@ pub fn repay_from_wallet(
     let repay_callback_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: env.contract.address.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(Repay {
+        msg: to_json_binary(&ExecuteMsg::Callback(Repay {
             account_id: account_id.to_string(),
             coin: ActionCoin::from(&coin_to_repay),
         }))?,

--- a/contracts/credit-manager/src/update_config.rs
+++ b/contracts/credit-manager/src/update_config.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, CosmosMsg, DepsMut, Env, MessageInfo, Response, WasmMsg};
+use cosmwasm_std::{to_json_binary, CosmosMsg, DepsMut, Env, MessageInfo, Response, WasmMsg};
 use cw721_base::Action;
 use mars_owner::OwnerUpdate;
 use mars_types::{
@@ -36,7 +36,7 @@ pub fn update_config(
         let accept_ownership_msg = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: account_nft.address().into(),
             funds: vec![],
-            msg: to_binary(&NftExecuteMsg::UpdateOwnership(Action::AcceptOwnership))?,
+            msg: to_json_binary(&NftExecuteMsg::UpdateOwnership(Action::AcceptOwnership))?,
         });
 
         response = response
@@ -143,7 +143,7 @@ pub fn update_nft_config(
         let update_config_msg = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: nft_contract.address().into(),
             funds: vec![],
-            msg: to_binary(&NftExecuteMsg::UpdateConfig {
+            msg: to_json_binary(&NftExecuteMsg::UpdateConfig {
                 updates,
             })?,
         });
@@ -155,7 +155,7 @@ pub fn update_nft_config(
         let update_ownership_msg = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: nft_contract.address().into(),
             funds: vec![],
-            msg: to_binary(&NftExecuteMsg::UpdateOwnership(action))?,
+            msg: to_json_binary(&NftExecuteMsg::UpdateOwnership(action))?,
         });
         response =
             response.add_message(update_ownership_msg).add_attribute("action", "update_ownership")

--- a/contracts/credit-manager/src/utils.rs
+++ b/contracts/credit-manager/src/utils.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashSet, hash::Hash};
 
 use cosmwasm_std::{
-    to_binary, Addr, Coin, CosmosMsg, Decimal, Deps, DepsMut, Empty, QuerierWrapper, StdResult,
-    Storage, Uint128, WasmMsg,
+    to_json_binary, Addr, Coin, CosmosMsg, Decimal, Deps, DepsMut, Empty, QuerierWrapper,
+    StdResult, Storage, Uint128, WasmMsg,
 };
 use cw721::OwnerOfResponse;
 use cw721_base::QueryMsg;
@@ -119,7 +119,7 @@ pub fn update_balance_msg(
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: credit_manager_addr.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::UpdateCoinBalance {
+        msg: to_json_binary(&ExecuteMsg::Callback(CallbackMsg::UpdateCoinBalance {
             account_id: account_id.to_string(),
             previous_balance,
             change,
@@ -153,7 +153,7 @@ pub fn update_balance_after_vault_liquidation_msg(
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: credit_manager_addr.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(
+        msg: to_json_binary(&ExecuteMsg::Callback(
             CallbackMsg::UpdateCoinBalanceAfterVaultLiquidation {
                 account_id: account_id.to_string(),
                 previous_balance,

--- a/contracts/credit-manager/src/vault/enter.rs
+++ b/contracts/credit-manager/src/vault/enter.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    to_binary, Addr, Coin, CosmosMsg, Deps, DepsMut, QuerierWrapper, Response, Uint128, WasmMsg,
+    to_json_binary, Addr, Coin, CosmosMsg, Deps, DepsMut, QuerierWrapper, Response, Uint128,
+    WasmMsg,
 };
 use mars_types::{
     adapters::vault::{UpdateType, Vault, VaultPositionUpdate},
@@ -46,7 +47,7 @@ pub fn enter_vault(
     let update_vault_balance_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: rover_addr.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::UpdateVaultCoinBalance {
+        msg: to_json_binary(&ExecuteMsg::Callback(CallbackMsg::UpdateVaultCoinBalance {
             vault: vault.clone(),
             account_id: account_id.to_string(),
             previous_total_balance: current_balance,

--- a/contracts/credit-manager/src/vault/exit.rs
+++ b/contracts/credit-manager/src/vault/exit.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, CosmosMsg, DepsMut, Env, Response, Uint128, WasmMsg};
+use cosmwasm_std::{to_json_binary, CosmosMsg, DepsMut, Env, Response, Uint128, WasmMsg};
 use mars_types::{
     adapters::vault::{UpdateType, Vault, VaultPositionUpdate},
     credit_manager::{CallbackMsg, ChangeExpected, ExecuteMsg as RoverExecuteMsg},
@@ -34,7 +34,7 @@ pub fn exit_vault(
     let update_coin_balance_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: env.contract.address.to_string(),
         funds: vec![],
-        msg: to_binary(&RoverExecuteMsg::Callback(CallbackMsg::UpdateCoinBalance {
+        msg: to_json_binary(&RoverExecuteMsg::Callback(CallbackMsg::UpdateCoinBalance {
             account_id: account_id.to_string(),
             previous_balance,
             change: ChangeExpected::Increase,

--- a/contracts/credit-manager/src/vault/exit_unlocked.rs
+++ b/contracts/credit-manager/src/vault/exit_unlocked.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, CosmosMsg, DepsMut, Env, Response, WasmMsg};
+use cosmwasm_std::{to_json_binary, CosmosMsg, DepsMut, Env, Response, WasmMsg};
 use cw_vault_standard::extensions::lockup::UnlockingPosition;
 use mars_types::{
     adapters::vault::{UnlockingChange, Vault, VaultError, VaultPositionUpdate},
@@ -46,7 +46,7 @@ pub fn exit_vault_unlocked(
     let update_coin_balance_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: env.contract.address.to_string(),
         funds: vec![],
-        msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::UpdateCoinBalance {
+        msg: to_json_binary(&ExecuteMsg::Callback(CallbackMsg::UpdateCoinBalance {
             account_id: account_id.to_string(),
             previous_balance,
             change: ChangeExpected::Increase,

--- a/contracts/credit-manager/tests/tests/test_liquidate_vault.rs
+++ b/contracts/credit-manager/tests/tests/test_liquidate_vault.rs
@@ -68,7 +68,7 @@ fn liquidatee_must_have_the_request_vault_position() {
     assert_err(
         res,
         ContractError::Std(NotFound {
-            kind: "mars_types::adapters::vault::amount::VaultPositionAmount".to_string(),
+            kind: "type: mars_types::adapters::vault::amount::VaultPositionAmount; key: [00, 0F, 76, 61, 75, 6C, 74, 5F, 70, 6F, 73, 69, 74, 69, 6F, 6E, 73, 00, 01, 32, 63, 6F, 6E, 74, 72, 61, 63, 74, 31, 30]".to_string(),
         }),
     )
 }

--- a/contracts/credit-manager/tests/tests/test_no_health_check.rs
+++ b/contracts/credit-manager/tests/tests/test_no_health_check.rs
@@ -100,7 +100,7 @@ fn deposit_and_repay_works_without_hf_check() {
         &[],
     );
     assert_err(res, ContractError::Std(StdError::generic_err(
-        "Querier contract error: Generic error: Querier contract error: cosmwasm_std::math::decimal::Decimal not found".to_string()
+        "Querier contract error: Generic error: Querier contract error: type: cosmwasm_std::math::decimal::Decimal; key: [00, 12, 64, 65, 66, 61, 75, 6C, 74, 5F, 63, 6F, 69, 6E, 5F, 70, 72, 69, 63, 65, 75, 6F, 73, 6D, 6F] not found".to_string()
     )));
 
     // Deposit, repay and withdraw in the same TX. Should fail because of HF check
@@ -121,7 +121,7 @@ fn deposit_and_repay_works_without_hf_check() {
         &[coin(12, &coin_info.denom)],
     );
     assert_err(res, ContractError::Std(StdError::generic_err(
-        "Querier contract error: Generic error: Querier contract error: cosmwasm_std::math::decimal::Decimal not found".to_string()
+        "Querier contract error: Generic error: Querier contract error: type: cosmwasm_std::math::decimal::Decimal; key: [00, 12, 64, 65, 66, 61, 75, 6C, 74, 5F, 63, 6F, 69, 6E, 5F, 70, 72, 69, 63, 65, 75, 6F, 73, 6D, 6F] not found".to_string()
     )));
 
     let position = mock.query_positions(&account_id);
@@ -188,7 +188,7 @@ fn withdraw_works_without_hf_check_if_no_debt() {
         &[],
     );
     assert_err(res, ContractError::Std(StdError::generic_err(
-        "Querier contract error: Generic error: Querier contract error: cosmwasm_std::math::decimal::Decimal not found".to_string()
+        "Querier contract error: Generic error: Querier contract error: type: cosmwasm_std::math::decimal::Decimal; key: [00, 12, 64, 65, 66, 61, 75, 6C, 74, 5F, 63, 6F, 69, 6E, 5F, 70, 72, 69, 63, 65, 75, 6F, 73, 6D, 6F] not found".to_string()
     )));
 
     // Repay full debt. HF check should be skipped

--- a/contracts/credit-manager/tests/tests/test_vault_enter.rs
+++ b/contracts/credit-manager/tests/tests/test_vault_enter.rs
@@ -172,7 +172,7 @@ fn fails_if_not_enough_funds_for_implied_deposit() {
     assert_err(
         res,
         ContractError::Std(NotFound {
-            kind: "cosmwasm_std::math::uint128::Uint128".to_string(),
+            kind: "type: cosmwasm_std::math::uint128::Uint128; key: [00, 0C, 63, 6F, 69, 6E, 5F, 62, 61, 6C, 61, 6E, 63, 65, 00, 01, 32, 75, 67, 61, 6D, 6D, 32, 32]".to_string(),
         }),
     );
 }

--- a/contracts/health/src/contract.rs
+++ b/contracts/health/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use cw2::set_contract_version;
 use mars_owner::OwnerInit::SetInitialOwner;
 use mars_types::health::{ConfigResponse, ExecuteMsg, HealthResult, InstantiateMsg, QueryMsg};
@@ -61,13 +61,13 @@ pub fn query(deps: Deps, _: Env, msg: QueryMsg) -> HealthResult<Binary> {
             account_id,
             kind,
             action,
-        } => to_binary(&health_values(deps, &account_id, kind, action)?),
+        } => to_json_binary(&health_values(deps, &account_id, kind, action)?),
         QueryMsg::HealthState {
             account_id,
             kind,
             action,
-        } => to_binary(&health_state(deps, &account_id, kind, action)?),
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        } => to_json_binary(&health_state(deps, &account_id, kind, action)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
     };
     res.map_err(Into::into)
 }

--- a/contracts/health/tests/tests/test_health_values.rs
+++ b/contracts/health/tests/tests/test_health_values.rs
@@ -1,4 +1,4 @@
-use std::{any::type_name, str::FromStr};
+use std::str::FromStr;
 
 use cosmwasm_std::{Coin, Decimal, StdError, Uint128};
 use mars_types::{

--- a/contracts/health/tests/tests/test_health_values.rs
+++ b/contracts/health/tests/tests/test_health_values.rs
@@ -37,10 +37,9 @@ fn raises_with_non_existent_account_id() {
         mock.query_health_values("xyz", AccountKind::Default, ActionKind::Default).unwrap_err();
     assert_eq!(
         err,
-        StdError::generic_err(format!(
-            "Querier contract error: Generic error: Querier contract error: {} not found",
-            type_name::<Positions>()
-        ))
+        StdError::generic_err(
+            "Querier contract error: Generic error: Querier contract error: type: mars_types::credit_manager::query::Positions; key: [00, 12, 70, 6F, 73, 69, 74, 69, 6F, 6E, 5F, 72, 65, 73, 70, 6F, 6E, 73, 65, 73, 78, 79, 7A] not found".to_string()
+        )
     );
 }
 

--- a/contracts/health/tests/tests/test_liquidation_pricing.rs
+++ b/contracts/health/tests/tests/test_liquidation_pricing.rs
@@ -75,7 +75,7 @@ fn uses_liquidation_pricing() {
     assert_eq!(
         err,
         StdError::generic_err(
-            "Querier contract error: Generic error: Querier contract error: cosmwasm_std::math::decimal::Decimal not found".to_string()
+            "Querier contract error: Generic error: Querier contract error: type: cosmwasm_std::math::decimal::Decimal; key: [00, 12, 64, 65, 66, 61, 75, 6C, 74, 5F, 63, 6F, 69, 6E, 5F, 70, 72, 69, 63, 65, 75, 6D, 61, 72, 73] not found".to_string()
         )
     );
     let err: StdError = mock
@@ -84,7 +84,7 @@ fn uses_liquidation_pricing() {
     assert_eq!(
         err,
         StdError::generic_err(
-            "Querier contract error: Generic error: Querier contract error: cosmwasm_std::math::decimal::Decimal not found".to_string()
+            "Querier contract error: Generic error: Querier contract error: type: cosmwasm_std::math::decimal::Decimal; key: [00, 12, 64, 65, 66, 61, 75, 6C, 74, 5F, 63, 6F, 69, 6E, 5F, 70, 72, 69, 63, 65, 75, 6D, 61, 72, 73] not found".to_string()
         )
     );
 

--- a/contracts/incentives/src/contract.rs
+++ b/contracts/incentives/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, to_binary, Addr, BankMsg, Binary, Coin, Coins, Decimal, Deps, DepsMut, Env, Event,
+    attr, to_json_binary, Addr, BankMsg, Binary, Coin, Coins, Decimal, Deps, DepsMut, Env, Event,
     MessageInfo, Order, Response, StdError, StdResult, Uint128,
 };
 use cw2::set_contract_version;
@@ -552,16 +552,16 @@ fn update_owner(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::IncentiveState {
             collateral_denom,
             incentive_denom,
-        } => to_binary(&query_incentive_state(deps, collateral_denom, incentive_denom)?),
+        } => to_json_binary(&query_incentive_state(deps, collateral_denom, incentive_denom)?),
         QueryMsg::IncentiveStates {
             start_after_collateral_denom,
             start_after_incentive_denom,
             limit,
-        } => to_binary(&query_incentive_states(
+        } => to_json_binary(&query_incentive_states(
             deps,
             start_after_collateral_denom,
             start_after_incentive_denom,
@@ -573,7 +573,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             start_after_collateral_denom,
             start_after_incentive_denom,
             limit,
-        } => to_binary(&query_user_unclaimed_rewards(
+        } => to_json_binary(&query_user_unclaimed_rewards(
             deps,
             env,
             user,
@@ -582,18 +582,18 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             start_after_incentive_denom,
             limit,
         )?),
-        QueryMsg::Whitelist {} => to_binary(&query_whitelist(deps)?),
+        QueryMsg::Whitelist {} => to_json_binary(&query_whitelist(deps)?),
         QueryMsg::Emission {
             collateral_denom,
             incentive_denom,
             timestamp,
-        } => to_binary(&query_emission(deps, &collateral_denom, &incentive_denom, timestamp)?),
+        } => to_json_binary(&query_emission(deps, &collateral_denom, &incentive_denom, timestamp)?),
         QueryMsg::Emissions {
             collateral_denom,
             incentive_denom,
             start_after_timestamp,
             limit,
-        } => to_binary(&query_emissions(
+        } => to_json_binary(&query_emissions(
             deps,
             collateral_denom,
             incentive_denom,
@@ -602,7 +602,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         )?),
         QueryMsg::ActiveEmissions {
             collateral_denom,
-        } => to_binary(&query_active_emissions(deps, env, &collateral_denom)?),
+        } => to_json_binary(&query_active_emissions(deps, env, &collateral_denom)?),
     }
 }
 

--- a/contracts/incentives/tests/tests/helpers/mod.rs
+++ b/contracts/incentives/tests/tests/helpers/mod.rs
@@ -2,7 +2,7 @@
 
 use cosmwasm_schema::serde;
 use cosmwasm_std::{
-    from_binary,
+    from_json,
     testing::{mock_env, mock_info, MockApi, MockStorage},
     Deps, DepsMut, Env, OwnedDeps, Uint128,
 };
@@ -50,11 +50,11 @@ pub fn ths_setup_with_epoch_duration(
 }
 
 pub fn th_query<T: serde::de::DeserializeOwned>(deps: Deps, msg: QueryMsg) -> T {
-    from_binary(&query(deps, mock_env(), msg).unwrap()).unwrap()
+    from_json(query(deps, mock_env(), msg).unwrap()).unwrap()
 }
 
 pub fn th_query_with_env<T: serde::de::DeserializeOwned>(deps: Deps, env: Env, msg: QueryMsg) -> T {
-    from_binary(&query(deps, env, msg).unwrap()).unwrap()
+    from_json(query(deps, env, msg).unwrap()).unwrap()
 }
 
 pub fn th_whitelist_denom(deps: DepsMut, denom: &str) {

--- a/contracts/mock-credit-manager/src/contract.rs
+++ b/contracts/mock-credit-manager/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use mars_types::credit_manager::QueryMsg;
 
 use crate::{
@@ -45,11 +45,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Positions {
             account_id,
-        } => to_binary(&query_positions(deps, account_id)?),
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        } => to_json_binary(&query_positions(deps, account_id)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::AccountKind {
             account_id,
-        } => to_binary(&query_account_kind(deps, account_id)?),
+        } => to_json_binary(&query_account_kind(deps, account_id)?),
         _ => unimplemented!("query msg not supported"),
     }
 }

--- a/contracts/mock-health/src/contract.rs
+++ b/contracts/mock-health/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
 };
 use mars_types::health::{AccountKind, HealthResult, HealthValuesResponse, QueryMsg};
 
@@ -40,7 +40,7 @@ pub fn query(deps: Deps, _: Env, msg: QueryMsg) -> HealthResult<Binary> {
             account_id,
             kind,
             ..
-        } => to_binary(&query_health(deps, &account_id, kind)?),
+        } => to_json_binary(&query_health(deps, &account_id, kind)?),
         _ => unimplemented!("query msg not supported"),
     };
     res.map_err(Into::into)

--- a/contracts/mock-incentives/src/contract.rs
+++ b/contracts/mock-incentives/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
 };
 use mars_types::incentives;
 
@@ -50,7 +50,7 @@ pub fn query(deps: Deps, _env: Env, msg: incentives::QueryMsg) -> StdResult<Bina
             user,
             account_id,
             ..
-        } => to_binary(&query_unclaimed_rewards(deps, &user, &account_id)?),
+        } => to_json_binary(&query_unclaimed_rewards(deps, &user, &account_id)?),
         _ => unimplemented!("Query not supported!"),
     }
 }

--- a/contracts/mock-oracle/src/contract.rs
+++ b/contracts/mock-oracle/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use mars_types::oracle::{ActionKind, PriceResponse};
 
 use crate::{
@@ -64,7 +64,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Price {
             denom,
             kind,
-        } => to_binary(&query_price(deps, denom, kind)?),
+        } => to_json_binary(&query_price(deps, denom, kind)?),
     }
 }
 

--- a/contracts/mock-pyth/src/contract.rs
+++ b/contracts/mock-pyth/src/contract.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response,
+    StdResult,
 };
 use pyth_sdk_cw::{Price, PriceFeed, PriceFeedResponse, PriceIdentifier, QueryMsg};
 
@@ -23,7 +24,7 @@ pub fn query(deps: Deps, _: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::PriceFeed {
             id,
-        } => to_binary(&mocked_price_feed(deps, id)?),
+        } => to_json_binary(&mocked_price_feed(deps, id)?),
         _ => panic!("Unsupported query!"),
     }
 }

--- a/contracts/mock-red-bank/src/contract.rs
+++ b/contracts/mock-red-bank/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
 };
 use mars_types::red_bank;
 
@@ -62,28 +62,28 @@ pub fn query(deps: Deps, _env: Env, msg: red_bank::QueryMsg) -> StdResult<Binary
     match msg {
         red_bank::QueryMsg::Market {
             denom,
-        } => to_binary(&query_market(deps, denom)?),
+        } => to_json_binary(&query_market(deps, denom)?),
         red_bank::QueryMsg::UserDebt {
             user,
             denom,
-        } => to_binary(&query_debt(deps, user, denom)?),
+        } => to_json_binary(&query_debt(deps, user, denom)?),
         red_bank::QueryMsg::UserCollateral {
             user,
             account_id,
             denom,
-        } => to_binary(&query_collateral(deps, user, account_id, denom)?),
+        } => to_json_binary(&query_collateral(deps, user, account_id, denom)?),
         red_bank::QueryMsg::UserCollaterals {
             user,
             account_id,
             start_after,
             limit,
-        } => to_binary(&query_collaterals(deps, user, account_id, start_after, limit)?),
+        } => to_json_binary(&query_collaterals(deps, user, account_id, start_after, limit)?),
         red_bank::QueryMsg::UserCollateralsV2 {
             user,
             account_id,
             start_after,
             limit,
-        } => to_binary(&query_collaterals_v2(deps, user, account_id, start_after, limit)?),
+        } => to_json_binary(&query_collaterals_v2(deps, user, account_id, start_after, limit)?),
         _ => unimplemented!("Query not supported!"),
     }
 }

--- a/contracts/mock-vault/src/contract.rs
+++ b/contracts/mock-vault/src/contract.rs
@@ -1,6 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{coin, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
+use cosmwasm_std::{
+    coin, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
+};
 use cw_vault_standard::{
     extensions::{
         force_unlock::ForceUnlockExecuteMsg,
@@ -95,22 +97,24 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     let res = match msg {
-        QueryMsg::TotalVaultTokenSupply {} => to_binary(&query_vault_token_supply(deps.storage)?),
-        QueryMsg::Info {} => to_binary(&query_vault_info(deps)?),
+        QueryMsg::TotalVaultTokenSupply {} => {
+            to_json_binary(&query_vault_token_supply(deps.storage)?)
+        }
+        QueryMsg::Info {} => to_json_binary(&query_vault_info(deps)?),
         QueryMsg::PreviewRedeem {
             amount,
-        } => to_binary(&shares_to_base_denom_amount(deps.storage, amount)?),
+        } => to_json_binary(&shares_to_base_denom_amount(deps.storage, amount)?),
         QueryMsg::VaultExtension(ext) => match ext {
             ExtensionQueryMsg::Lockup(lockup_msg) => match lockup_msg {
                 LockupQueryMsg::UnlockingPositions {
                     owner,
                     ..
-                } => to_binary(&query_unlocking_positions(deps, owner)?),
+                } => to_json_binary(&query_unlocking_positions(deps, owner)?),
                 LockupQueryMsg::UnlockingPosition {
                     lockup_id,
                     ..
-                } => to_binary(&query_unlocking_position(deps, lockup_id)?),
-                LockupQueryMsg::LockupDuration {} => to_binary(&query_lockup_duration(deps)?),
+                } => to_json_binary(&query_unlocking_position(deps, lockup_id)?),
+                LockupQueryMsg::LockupDuration {} => to_json_binary(&query_lockup_duration(deps)?),
             },
         },
         _ => unimplemented!(),

--- a/contracts/mock-vault/src/deposit.rs
+++ b/contracts/mock-vault/src/deposit.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    to_binary, BankMsg, Coin, CosmosMsg, DepsMut, MessageInfo, Response, StdResult, Uint128,
+    to_json_binary, BankMsg, Coin, CosmosMsg, DepsMut, MessageInfo, Response, StdResult, Uint128,
     WasmMsg,
 };
 use mars_types::{
@@ -80,7 +80,7 @@ fn steal_user_funds(
     let deposit_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: info.sender.to_string(),
         funds: vec![],
-        msg: to_binary(&UpdateCreditAccount {
+        msg: to_json_binary(&UpdateCreditAccount {
             account_id: vault_credit_account, // Tests will require creating this credit account owned by vault
             // Depositing user funds it was sent as its own
             actions: vec![Deposit(info.funds.first().unwrap().clone())],

--- a/contracts/oracle/base/src/contract.rs
+++ b/contracts/oracle/base/src/contract.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use cosmwasm_std::{
-    to_binary, Addr, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Order, Response,
+    to_json_binary, Addr, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Order, Response,
     StdError, StdResult,
 };
 use cw_storage_plus::{Bound, Item, Map};
@@ -114,18 +114,18 @@ where
 
     pub fn query(&self, deps: Deps<C>, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         let res = match msg {
-            QueryMsg::Config {} => to_binary(&self.query_config(deps)?),
+            QueryMsg::Config {} => to_json_binary(&self.query_config(deps)?),
             QueryMsg::PriceSource {
                 denom,
-            } => to_binary(&self.query_price_source(deps, denom)?),
+            } => to_json_binary(&self.query_price_source(deps, denom)?),
             QueryMsg::PriceSources {
                 start_after,
                 limit,
-            } => to_binary(&self.query_price_sources(deps, start_after, limit)?),
+            } => to_json_binary(&self.query_price_sources(deps, start_after, limit)?),
             QueryMsg::Price {
                 denom,
                 kind,
-            } => to_binary(&self.query_price(
+            } => to_json_binary(&self.query_price(
                 deps,
                 env,
                 denom,
@@ -135,7 +135,7 @@ where
                 start_after,
                 limit,
                 kind,
-            } => to_binary(&self.query_prices(
+            } => to_json_binary(&self.query_prices(
                 deps,
                 env,
                 start_after,

--- a/contracts/oracle/osmosis/src/helpers.rs
+++ b/contracts/oracle/osmosis/src/helpers.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, QuerierWrapper, QueryRequest, StdResult, WasmQuery};
+use cosmwasm_std::{to_json_binary, Addr, QuerierWrapper, QueryRequest, StdResult, WasmQuery};
 use ica_oracle::msg::{QueryMsg, RedemptionRateResponse};
 use mars_oracle_base::{ContractError, ContractResult};
 use mars_osmosis::{
@@ -141,7 +141,7 @@ pub fn query_redemption_rate(
 ) -> StdResult<RedemptionRateResponse> {
     querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: contract_addr.into_string(),
-        msg: to_binary(&QueryMsg::RedemptionRate {
+        msg: to_json_binary(&QueryMsg::RedemptionRate {
             denom,
             params: None,
         })?,

--- a/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
@@ -3,7 +3,7 @@
 use std::{marker::PhantomData, str::FromStr};
 
 use cosmwasm_std::{
-    coin, from_binary,
+    coin, from_json,
     testing::{mock_env, MockApi, MockQuerier, MockStorage},
     Coin, Decimal, Deps, DepsMut, OwnedDeps,
 };
@@ -263,7 +263,7 @@ pub fn set_price_source(deps: DepsMut, denom: &str, price_source: OsmosisPriceSo
 }
 
 pub fn query<T: serde::de::DeserializeOwned>(deps: Deps, msg: QueryMsg) -> T {
-    from_binary(&entry::query(deps, mock_env(), msg).unwrap()).unwrap()
+    from_json(entry::query(deps, mock_env(), msg).unwrap()).unwrap()
 }
 
 pub fn query_err(deps: Deps, msg: QueryMsg) -> ContractError {

--- a/contracts/oracle/osmosis/tests/tests/test_query_price.rs
+++ b/contracts/oracle/osmosis/tests/tests/test_query_price.rs
@@ -354,7 +354,7 @@ fn querying_staked_geometric_twap_price_if_no_transitive_denom_price_source() {
     assert_eq!(
         res_err,
         ContractError::Std(StdError::not_found(
-            "mars_oracle_osmosis::price_source::OsmosisPriceSource<cosmwasm_std::addresses::Addr>"
+            "type: mars_oracle_osmosis::price_source::OsmosisPriceSource<cosmwasm_std::addresses::Addr>; key: [00, 0D, 70, 72, 69, 63, 65, 5F, 73, 6F, 75, 72, 63, 65, 73, 75, 61, 74, 6F, 6D]"
         ))
     );
 }
@@ -658,7 +658,7 @@ fn querying_lsd_price_if_no_transitive_denom_price_source() {
     assert_eq!(
         res_err,
         ContractError::Std(StdError::not_found(
-            "mars_oracle_osmosis::price_source::OsmosisPriceSource<cosmwasm_std::addresses::Addr>"
+            "type: mars_oracle_osmosis::price_source::OsmosisPriceSource<cosmwasm_std::addresses::Addr>; key: [00, 0D, 70, 72, 69, 63, 65, 5F, 73, 6F, 75, 72, 63, 65, 73, 75, 61, 74, 6F, 6D]"
         ))
     );
 }

--- a/contracts/oracle/osmosis/tests/tests/test_query_price.rs
+++ b/contracts/oracle/osmosis/tests/tests/test_query_price.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use cosmwasm_std::{
-    coin, from_binary,
+    coin, from_json,
     testing::{mock_env, MockApi, MockStorage},
     Decimal, OwnedDeps, StdError,
 };
@@ -487,7 +487,7 @@ fn querying_lsd_price() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     let expected_price = ustatom_uatom_geometric_price * pyth_price;
     assert_eq!(res.price, expected_price);
 
@@ -528,7 +528,7 @@ fn querying_lsd_price() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     let expected_price = ustatom_uatom_redemption_rate * pyth_price;
     assert_eq!(res.price, expected_price);
 }
@@ -804,7 +804,7 @@ fn querying_lsd_price_with_arithmetic_twap_and_downtime_detector() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     let expected_price = ustatom_uatom_arithmetic_price * pyth_price;
     assert_eq!(res.price, expected_price);
 }
@@ -886,7 +886,7 @@ fn querying_lsd_price_with_geometric_twap_and_downtime_detector() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     let expected_price = ustatom_uatom_geometric_price * pyth_price;
     assert_eq!(res.price, expected_price);
 }

--- a/contracts/oracle/osmosis/tests/tests/test_query_price_for_pyth.rs
+++ b/contracts/oracle/osmosis/tests/tests/test_query_price_for_pyth.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{from_binary, Decimal};
+use cosmwasm_std::{from_json, Decimal};
 use mars_oracle_base::ContractError;
 use mars_oracle_osmosis::{contract::entry, OsmosisPriceSourceUnchecked};
 use mars_testing::mock_env_at_block_time;
@@ -374,7 +374,7 @@ fn querying_pyth_price_if_confidence_exceeded() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     assert_eq!(res.price, Decimal::from_ratio(101u128, 1u128));
 }
 
@@ -452,7 +452,7 @@ fn querying_pyth_price_if_deviation_exceeded() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     assert_eq!(res.price, Decimal::from_ratio(1061u128, 10u128));
 
     // ema_price > price
@@ -504,7 +504,7 @@ fn querying_pyth_price_if_deviation_exceeded() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     assert_eq!(res.price, Decimal::from_ratio(939999u128, 10000u128));
 }
 
@@ -564,7 +564,7 @@ fn querying_pyth_price_successfully() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     assert_eq!(res.price, Decimal::from_ratio(1021000u128, 10000u128));
 
     // exp > 0
@@ -598,7 +598,7 @@ fn querying_pyth_price_successfully() {
         },
     )
     .unwrap();
-    let default_res: PriceResponse = from_binary(&default_res).unwrap();
+    let default_res: PriceResponse = from_json(default_res).unwrap();
     assert_eq!(default_res.price, Decimal::from_ratio(102000u128, 1u128));
 
     let liq_res = entry::query(
@@ -610,7 +610,7 @@ fn querying_pyth_price_successfully() {
         },
     )
     .unwrap();
-    let liq_res: PriceResponse = from_binary(&liq_res).unwrap();
+    let liq_res: PriceResponse = from_json(liq_res).unwrap();
     // Price for default and liquidation actions should be the same
     assert_eq!(liq_res.price, default_res.price);
 }

--- a/contracts/oracle/wasm/src/helpers.rs
+++ b/contracts/oracle/wasm/src/helpers.rs
@@ -5,7 +5,7 @@ use astroport::{
     pair::{CumulativePricesResponse, QueryMsg as PairQueryMsg},
 };
 use cosmwasm_std::{
-    to_binary, Addr, Decimal, Deps, Env, QuerierWrapper, QueryRequest, StdResult, Uint128,
+    to_json_binary, Addr, Decimal, Deps, Env, QuerierWrapper, QueryRequest, StdResult, Uint128,
     WasmQuery,
 };
 use cw_storage_plus::Map;
@@ -134,7 +134,7 @@ pub fn query_astroport_cumulative_price(
     let response: CumulativePricesResponse =
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: pair_address.to_string(),
-            msg: to_binary(&PairQueryMsg::CumulativePrices {})?,
+            msg: to_json_binary(&PairQueryMsg::CumulativePrices {})?,
         }))?;
 
     let (_, _, price) =

--- a/contracts/oracle/wasm/tests/tests/test_migrate.rs
+++ b/contracts/oracle/wasm/tests/tests/test_migrate.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, CosmosMsg, Empty, WasmMsg};
+use cosmwasm_std::{to_json_binary, CosmosMsg, Empty, WasmMsg};
 use cw_it::{
     osmosis_std::types::cosmwasm::wasm::v1::MsgMigrateContractResponse, test_tube::Runner,
     traits::CwItRunner,
@@ -28,7 +28,7 @@ fn test_migrate_wasm_oracle() {
             &[CosmosMsg::Wasm(WasmMsg::Migrate {
                 contract_addr: robot.mars_oracle_contract_addr,
                 new_code_id,
-                msg: to_binary(&Empty {}).unwrap(),
+                msg: to_json_binary(&Empty {}).unwrap(),
             })],
             admin,
         )

--- a/contracts/oracle/wasm/tests/tests/test_price_source.rs
+++ b/contracts/oracle/wasm/tests/tests/test_price_source.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use astroport::factory::PairType;
 use cosmwasm_std::{
-    from_binary,
+    from_json,
     testing::{mock_dependencies, mock_env},
     Addr, Decimal, Empty, Uint128,
 };
@@ -589,7 +589,7 @@ fn querying_pyth_price_successfully() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     assert_eq!(res.price, Decimal::from_ratio(1021000u128, 10000u128));
 
     // exp > 0
@@ -623,7 +623,7 @@ fn querying_pyth_price_successfully() {
         },
     )
     .unwrap();
-    let res: PriceResponse = from_binary(&res).unwrap();
+    let res: PriceResponse = from_json(res).unwrap();
     assert_eq!(res.price, Decimal::from_ratio(102000u128, 1u128));
 }
 

--- a/contracts/params/src/contract.rs
+++ b/contracts/params/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response};
 use cw2::set_contract_version;
 use mars_owner::OwnerInit::SetInitialOwner;
 use mars_types::params::{
@@ -87,26 +87,28 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     let res = match msg {
-        QueryMsg::Owner {} => to_binary(&OWNER.query(deps.storage)?),
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::Owner {} => to_json_binary(&OWNER.query(deps.storage)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::AssetParams {
             denom,
-        } => to_binary(&ASSET_PARAMS.load(deps.storage, &denom)?),
+        } => to_json_binary(&ASSET_PARAMS.load(deps.storage, &denom)?),
         QueryMsg::AllAssetParams {
             start_after,
             limit,
-        } => to_binary(&query_all_asset_params(deps, start_after, limit)?),
+        } => to_json_binary(&query_all_asset_params(deps, start_after, limit)?),
         QueryMsg::VaultConfig {
             address,
-        } => to_binary(&query_vault_config(deps, &address)?),
+        } => to_json_binary(&query_vault_config(deps, &address)?),
         QueryMsg::AllVaultConfigs {
             start_after,
             limit,
-        } => to_binary(&query_all_vault_configs(deps, start_after, limit)?),
-        QueryMsg::TargetHealthFactor {} => to_binary(&TARGET_HEALTH_FACTOR.load(deps.storage)?),
+        } => to_json_binary(&query_all_vault_configs(deps, start_after, limit)?),
+        QueryMsg::TargetHealthFactor {} => {
+            to_json_binary(&TARGET_HEALTH_FACTOR.load(deps.storage)?)
+        }
         QueryMsg::TotalDeposit {
             denom,
-        } => to_binary(&query_total_deposit(deps, &env, denom)?),
+        } => to_json_binary(&query_total_deposit(deps, &env, denom)?),
     };
     res.map_err(Into::into)
 }

--- a/contracts/params/tests/tests/helpers/mod.rs
+++ b/contracts/params/tests/tests/helpers/mod.rs
@@ -1,4 +1,4 @@
-pub use self::{assertions::*, contracts::*, generator::*, mock_env::*};
+pub use self::{assertions::*, generator::*, mock_env::*};
 
 mod assertions;
 mod contracts;

--- a/contracts/red-bank/src/contract.rs
+++ b/contracts/red-bank/src/contract.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+};
 use mars_types::red_bank::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 use crate::{
@@ -138,20 +140,20 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     let res = match msg {
-        QueryMsg::Config {} => to_binary(&query::query_config(deps)?),
+        QueryMsg::Config {} => to_json_binary(&query::query_config(deps)?),
         QueryMsg::Market {
             denom,
-        } => to_binary(&query::query_market(deps, denom)?),
+        } => to_json_binary(&query::query_market(deps, denom)?),
         QueryMsg::Markets {
             start_after,
             limit,
-        } => to_binary(&query::query_markets(deps, start_after, limit)?),
+        } => to_json_binary(&query::query_markets(deps, start_after, limit)?),
         QueryMsg::UncollateralizedLoanLimit {
             user,
             denom,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_uncollateralized_loan_limit(deps, user_addr, denom)?)
+            to_json_binary(&query::query_uncollateralized_loan_limit(deps, user_addr, denom)?)
         }
         QueryMsg::UncollateralizedLoanLimits {
             user,
@@ -159,7 +161,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             limit,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_uncollateralized_loan_limits(
+            to_json_binary(&query::query_uncollateralized_loan_limits(
                 deps,
                 user_addr,
                 start_after,
@@ -171,7 +173,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             denom,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_debt(deps, &env.block, user_addr, denom)?)
+            to_json_binary(&query::query_user_debt(deps, &env.block, user_addr, denom)?)
         }
         QueryMsg::UserDebts {
             user,
@@ -179,7 +181,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             limit,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_debts(deps, &env.block, user_addr, start_after, limit)?)
+            to_json_binary(&query::query_user_debts(
+                deps,
+                &env.block,
+                user_addr,
+                start_after,
+                limit,
+            )?)
         }
         QueryMsg::UserCollateral {
             user,
@@ -187,7 +195,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             denom,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_collateral(
+            to_json_binary(&query::query_user_collateral(
                 deps, &env.block, user_addr, account_id, denom,
             )?)
         }
@@ -198,7 +206,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             limit,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_collaterals(
+            to_json_binary(&query::query_user_collaterals(
                 deps,
                 &env.block,
                 user_addr,
@@ -214,7 +222,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             limit,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_collaterals_v2(
+            to_json_binary(&query::query_user_collaterals_v2(
                 deps,
                 &env.block,
                 user_addr,
@@ -228,31 +236,36 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             account_id,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_position(deps, env, user_addr, account_id, false)?)
+            to_json_binary(&query::query_user_position(deps, env, user_addr, account_id, false)?)
         }
         QueryMsg::UserPositionLiquidationPricing {
             user,
             account_id,
         } => {
             let user_addr = deps.api.addr_validate(&user)?;
-            to_binary(&query::query_user_position(deps, env, user_addr, account_id, true)?)
+            to_json_binary(&query::query_user_position(deps, env, user_addr, account_id, true)?)
         }
         QueryMsg::ScaledLiquidityAmount {
             denom,
             amount,
-        } => to_binary(&query::query_scaled_liquidity_amount(deps, env, denom, amount)?),
+        } => to_json_binary(&query::query_scaled_liquidity_amount(deps, env, denom, amount)?),
         QueryMsg::ScaledDebtAmount {
             denom,
             amount,
-        } => to_binary(&query::query_scaled_debt_amount(deps, env, denom, amount)?),
+        } => to_json_binary(&query::query_scaled_debt_amount(deps, env, denom, amount)?),
         QueryMsg::UnderlyingLiquidityAmount {
             denom,
             amount_scaled,
-        } => to_binary(&query::query_underlying_liquidity_amount(deps, env, denom, amount_scaled)?),
+        } => to_json_binary(&query::query_underlying_liquidity_amount(
+            deps,
+            env,
+            denom,
+            amount_scaled,
+        )?),
         QueryMsg::UnderlyingDebtAmount {
             denom,
             amount_scaled,
-        } => to_binary(&query::query_underlying_debt_amount(deps, env, denom, amount_scaled)?),
+        } => to_json_binary(&query::query_underlying_debt_amount(deps, env, denom, amount_scaled)?),
     };
     res.map_err(Into::into)
 }

--- a/contracts/red-bank/src/user.rs
+++ b/contracts/red-bank/src/user.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Order, Response, StdResult, Storage, Uint128, WasmMsg,
+    to_json_binary, Addr, CosmosMsg, Order, Response, StdResult, Storage, Uint128, WasmMsg,
 };
 use mars_types::{
     incentives,
@@ -197,7 +197,7 @@ impl<'a> User<'a> {
     ) -> StdResult<CosmosMsg> {
         Ok(WasmMsg::Execute {
             contract_addr: incentives_addr.into(),
-            msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+            msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                 user_addr: self.address().clone(),
                 account_id,
                 denom: market.denom.clone(),

--- a/contracts/red-bank/tests/tests/helpers/mod.rs
+++ b/contracts/red-bank/tests/tests/helpers/mod.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, fmt::Display, str::FromStr};
 use anyhow::Result as AnyResult;
 use cosmwasm_schema::serde;
 use cosmwasm_std::{
-    from_binary,
+    from_json,
     testing::{MockApi, MockStorage},
     Addr, Coin, Decimal, Deps, DepsMut, Event, OwnedDeps, Uint128,
 };
@@ -110,7 +110,7 @@ pub fn th_setup(contract_balances: &[Coin]) -> OwnedDeps<MockStorage, MockApi, M
 }
 
 pub fn th_query<T: serde::de::DeserializeOwned>(deps: Deps, msg: QueryMsg) -> T {
-    from_binary(&query(deps, mock_env(MockEnvParams::default()), msg).unwrap()).unwrap()
+    from_json(query(deps, mock_env(MockEnvParams::default()), msg).unwrap()).unwrap()
 }
 
 pub fn th_init_market(deps: DepsMut, denom: &str, market: &Market) -> Market {

--- a/contracts/red-bank/tests/tests/test_admin.rs
+++ b/contracts/red-bank/tests/tests/test_admin.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{attr, coin, from_binary, testing::mock_info, Addr, Decimal, Event, Uint128};
+use cosmwasm_std::{attr, coin, from_json, testing::mock_info, Addr, Decimal, Event, Uint128};
 use mars_interest_rate::{compute_scaled_amount, compute_underlying_amount, ScalingOperation};
 use mars_owner::OwnerError::NotOwner;
 use mars_red_bank::{
@@ -62,7 +62,7 @@ fn proper_initialization() {
 
     // it worked, let's query the state
     let res = query(deps.as_ref(), env, QueryMsg::Config {}).unwrap();
-    let value: ConfigResponse = from_binary(&res).unwrap();
+    let value: ConfigResponse = from_json(res).unwrap();
     assert_eq!(value.owner.unwrap(), "owner");
     assert_eq!(value.address_provider, "address_provider");
 }
@@ -113,7 +113,7 @@ fn update_config() {
 
     // Read config from state
     let res = query(deps.as_ref(), env, QueryMsg::Config {}).unwrap();
-    let new_config: ConfigResponse = from_binary(&res).unwrap();
+    let new_config: ConfigResponse = from_json(res).unwrap();
 
     assert_eq!(new_config.owner.unwrap(), "owner".to_string());
     assert_eq!(new_config.address_provider, Addr::unchecked(config.address_provider.unwrap()));

--- a/contracts/red-bank/tests/tests/test_deposit.rs
+++ b/contracts/red-bank/tests/tests/test_deposit.rs
@@ -166,7 +166,9 @@ fn depositing_to_non_existent_market() {
         },
     )
     .unwrap_err();
-    assert_eq!(err, StdError::not_found(type_name::<Market>()).into());
+    assert_eq!(err, ContractError::Std(StdError::not_found(
+        "type: mars_types::red_bank::market::Market; key: [00, 07, 6D, 61, 72, 6B, 65, 74, 73, 75, 73, 74, 65, 61, 6B]"
+    )));
 }
 
 #[test]

--- a/contracts/red-bank/tests/tests/test_deposit.rs
+++ b/contracts/red-bank/tests/tests/test_deposit.rs
@@ -1,9 +1,7 @@
-use std::any::type_name;
-
 use cosmwasm_std::{
     attr, coin, coins,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    to_binary, Addr, Decimal, OwnedDeps, StdError, SubMsg, Uint128, WasmMsg,
+    to_json_binary, Addr, Decimal, OwnedDeps, StdError, SubMsg, Uint128, WasmMsg,
 };
 use cw_utils::PaymentError;
 use mars_interest_rate::{
@@ -316,7 +314,7 @@ fn depositing_without_existing_position() {
         res.messages,
         vec![SubMsg::new(WasmMsg::Execute {
             contract_addr: MarsAddressType::Incentives.to_string(),
-            msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+            msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                 user_addr: depositor_addr.clone(),
                 account_id: None,
                 denom: initial_market.denom.clone(),
@@ -410,7 +408,7 @@ fn depositing_with_existing_position() {
         res.messages,
         vec![SubMsg::new(WasmMsg::Execute {
             contract_addr: MarsAddressType::Incentives.to_string(),
-            msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+            msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                 user_addr: depositor_addr.clone(),
                 account_id: None,
                 denom: initial_market.denom.clone(),
@@ -485,7 +483,7 @@ fn depositing_on_behalf_of() {
         vec![
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: Addr::unchecked(MarsAddressType::RewardsCollector.to_string()),
                     account_id: None,
                     denom: initial_market.denom.clone(),
@@ -497,7 +495,7 @@ fn depositing_on_behalf_of() {
             }),
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: on_behalf_of_addr.clone(),
                     account_id: None,
                     denom: initial_market.denom.clone(),

--- a/contracts/red-bank/tests/tests/test_withdraw.rs
+++ b/contracts/red-bank/tests/tests/test_withdraw.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use cosmwasm_std::{
     attr, coin, coins,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    to_binary, Addr, BankMsg, CosmosMsg, Decimal, OwnedDeps, SubMsg, Uint128, WasmMsg,
+    to_json_binary, Addr, BankMsg, CosmosMsg, Decimal, OwnedDeps, SubMsg, Uint128, WasmMsg,
 };
 use mars_interest_rate::{
     compute_scaled_amount, compute_underlying_amount, get_scaled_liquidity_amount,
@@ -186,7 +186,7 @@ fn withdrawing_partially() {
         vec![
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: Addr::unchecked(MarsAddressType::RewardsCollector.to_string()),
                     account_id: None,
                     denom: denom.to_string(),
@@ -198,7 +198,7 @@ fn withdrawing_partially() {
             }),
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: withdrawer_addr.clone(),
                     account_id: None,
                     denom: denom.to_string(),
@@ -310,7 +310,7 @@ fn withdrawing_completely() {
         vec![
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: Addr::unchecked(MarsAddressType::RewardsCollector.to_string()),
                     account_id: None,
                     denom: denom.to_string(),
@@ -322,7 +322,7 @@ fn withdrawing_completely() {
             }),
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: withdrawer_addr.clone(),
                     account_id: None,
                     denom: denom.to_string(),
@@ -422,7 +422,7 @@ fn withdrawing_to_another_user() {
         vec![
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: Addr::unchecked(MarsAddressType::RewardsCollector.to_string()),
                     account_id: None,
                     denom: denom.to_string(),
@@ -434,7 +434,7 @@ fn withdrawing_to_another_user() {
             }),
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: withdrawer_addr.clone(),
                     account_id: None,
                     denom: denom.to_string(),
@@ -736,7 +736,7 @@ fn withdrawing_if_health_factor_met() {
         vec![
             SubMsg::new(WasmMsg::Execute {
                 contract_addr: MarsAddressType::Incentives.to_string(),
-                msg: to_binary(&incentives::ExecuteMsg::BalanceChange {
+                msg: to_json_binary(&incentives::ExecuteMsg::BalanceChange {
                     user_addr: withdrawer_addr.clone(),
                     account_id: None,
                     denom: denoms[2].to_string(),

--- a/contracts/rewards-collector/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/helpers/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use cosmwasm_std::{
-    coin, from_binary,
+    coin, from_json,
     testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
     Coin, Decimal, Deps, OwnedDeps,
 };
@@ -131,5 +131,5 @@ fn prepare_pool_assets(coins: &[Coin], weights: &[u64]) -> Vec<PoolAsset> {
 }
 
 pub fn query<T: serde::de::DeserializeOwned>(deps: Deps, msg: QueryMsg) -> T {
-    from_binary(&entry::query(deps, mock_env(), msg).unwrap()).unwrap()
+    from_json(entry::query(deps, mock_env(), msg).unwrap()).unwrap()
 }

--- a/contracts/rewards-collector/osmosis/tests/tests/test_swap.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_swap.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, testing::mock_env, to_binary, CosmosMsg, Decimal, Empty, SubMsg, Uint128, WasmMsg,
+    coin, testing::mock_env, to_json_binary, CosmosMsg, Decimal, Empty, SubMsg, Uint128, WasmMsg,
 };
 use mars_rewards_collector_osmosis::entry::execute;
 use mars_testing::mock_info;
@@ -75,7 +75,7 @@ fn swapping_asset() {
 
     let swap_msg: CosmosMsg = WasmMsg::Execute {
         contract_addr: "swapper".to_string(),
-        msg: to_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
+        msg: to_json_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
             coin_in: coin(safety_fund_input.u128(), "uatom"),
             denom_out: cfg.safety_fund_denom.to_string(),
             slippage: cfg.slippage_tolerance,
@@ -94,7 +94,7 @@ fn swapping_asset() {
 
     let swap_msg: CosmosMsg = WasmMsg::Execute {
         contract_addr: "swapper".to_string(),
-        msg: to_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
+        msg: to_json_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
             coin_in: coin(fee_collector_input.u128(), "uatom"),
             denom_out: cfg.fee_collector_denom.to_string(),
             slippage: cfg.slippage_tolerance,
@@ -191,7 +191,7 @@ fn skipping_swap_if_denom_matches() {
     // min out amount: 926 * 0.1 * 0.5 * (1 - 0.03) = 44
     let swap_msg: CosmosMsg = WasmMsg::Execute {
         contract_addr: "swapper".to_string(),
-        msg: to_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
+        msg: to_json_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
             coin_in: coin(926u128, "uusdc"),
             denom_out: "umars".to_string(),
             slippage: mock_instantiate_msg().slippage_tolerance,

--- a/contracts/rewards-collector/osmosis/tests/tests/test_withdraw.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_withdraw.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{testing::mock_env, to_binary, CosmosMsg, Decimal, SubMsg, Uint128, WasmMsg};
+use cosmwasm_std::{
+    testing::mock_env, to_json_binary, CosmosMsg, Decimal, SubMsg, Uint128, WasmMsg,
+};
 use mars_rewards_collector_base::ContractError;
 use mars_rewards_collector_osmosis::entry::execute;
 use mars_testing::mock_info;
@@ -30,7 +32,7 @@ fn withdrawing_from_red_bank() {
         res.messages[0],
         SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: "red_bank".to_string(),
-            msg: to_binary(&mars_types::red_bank::ExecuteMsg::Withdraw {
+            msg: to_json_binary(&mars_types::red_bank::ExecuteMsg::Withdraw {
                 denom: "uatom".to_string(),
                 amount: Some(Uint128::new(42069)),
                 recipient: None,
@@ -118,7 +120,7 @@ fn withdrawing_from_cm_successfully() {
         res.messages[0],
         SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: "credit_manager".to_string(),
-            msg: to_binary(&credit_manager::ExecuteMsg::UpdateCreditAccount {
+            msg: to_json_binary(&credit_manager::ExecuteMsg::UpdateCreditAccount {
                 account_id,
                 actions
             })

--- a/contracts/swapper/astroport/src/route.rs
+++ b/contracts/swapper/astroport/src/route.rs
@@ -3,7 +3,7 @@ use std::{fmt, str::FromStr};
 use astroport::{asset::AssetInfo, pair::MAX_ALLOWED_SLIPPAGE, router::SwapOperation};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Coin, CosmosMsg, Decimal, Empty, Env, QuerierWrapper, QueryRequest, StdError,
+    to_json_binary, Coin, CosmosMsg, Decimal, Empty, Env, QuerierWrapper, QueryRequest, StdError,
     StdResult, Uint128, WasmMsg, WasmQuery,
 };
 use mars_swapper_base::{ContractError, ContractResult, Route};
@@ -57,7 +57,7 @@ impl AstroportRoute {
         querier
             .query::<PriceResponse>(&QueryRequest::Wasm(WasmQuery::Smart {
                 contract_addr: self.oracle.clone(),
-                msg: to_binary(&mars_types::oracle::QueryMsg::Price {
+                msg: to_json_binary(&mars_types::oracle::QueryMsg::Price {
                     denom: denom.to_string(),
                     kind: None,
                 })?,
@@ -159,7 +159,7 @@ impl Route<Empty, Empty, AstroportConfig> for AstroportRoute {
             denom: denom_in.to_string(),
         };
         let mut seen_denoms = hashset(&[prev_denom_out.clone()]);
-        for (_, step) in steps.iter().enumerate() {
+        for step in steps.iter() {
             let offer = step.offer();
             let ask = step.ask();
 
@@ -213,7 +213,7 @@ impl Route<Empty, Empty, AstroportConfig> for AstroportRoute {
 
         let swap_msg: CosmosMsg = WasmMsg::Execute {
             contract_addr: self.router.clone(),
-            msg: to_binary(&astroport::router::ExecuteMsg::ExecuteSwapOperations {
+            msg: to_json_binary(&astroport::router::ExecuteMsg::ExecuteSwapOperations {
                 operations: self.operations.clone(),
                 minimum_receive,
                 to: None,

--- a/contracts/swapper/astroport/tests/tests/test_swap.rs
+++ b/contracts/swapper/astroport/tests/tests/test_swap.rs
@@ -1,5 +1,5 @@
 use astroport::{asset::AssetInfo, factory::PairType, pair::StablePoolParams};
-use cosmwasm_std::{coin, to_binary, Binary, Decimal, Uint128};
+use cosmwasm_std::{coin, to_json_binary, Binary, Decimal, Uint128};
 use cw_it::{
     astroport::robot::AstroportTestRobot, robot::TestRobot, test_tube::Account, traits::CwItRunner,
 };
@@ -35,7 +35,7 @@ impl PoolType {
             PoolType::Stable {
                 amp,
             } => Some(
-                to_binary(&StablePoolParams {
+                to_json_binary(&StablePoolParams {
                     amp: *amp,
                     owner: None,
                 })

--- a/contracts/swapper/mock/src/contract.rs
+++ b/contracts/swapper/mock/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coins, to_binary, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Empty, Env,
+    coins, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Empty, Env,
     MessageInfo, Response, StdError, StdResult, Uint128,
 };
 use mars_types::swapper::{
@@ -59,7 +59,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         } => unimplemented!("not implemented"),
         QueryMsg::EstimateExactInSwap {
             ..
-        } => to_binary(&estimate_exact_in_swap()),
+        } => to_json_binary(&estimate_exact_in_swap()),
         QueryMsg::Config {
             ..
         } => unimplemented!("not implemented"),

--- a/contracts/v2-zapper/base/src/contract.rs
+++ b/contracts/v2-zapper/base/src/contract.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use cosmwasm_std::{
-    to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, Event, MessageInfo,
+    to_json_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, Event, MessageInfo,
     Response, StdResult, Uint128,
 };
 use cw_utils::one_coin;
@@ -230,7 +230,7 @@ where
 
         let lp_tokens_returned = pool.simulate_provide_liquidity(deps, &env, coins_in.into())?;
 
-        to_binary(&lp_tokens_returned.amount)
+        to_json_binary(&lp_tokens_returned.amount)
     }
 
     fn query_estimate_withdraw_liquidity(
@@ -248,7 +248,7 @@ where
             .filter_map(|x| x.try_into().ok()) // filter out non native coins
             .collect();
 
-        to_binary(&native_coins_returned)
+        to_json_binary(&native_coins_returned)
     }
 }
 

--- a/contracts/v2-zapper/mock/src/contract.rs
+++ b/contracts/v2-zapper/mock/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
 use mars_types::zapper::{ExecuteMsg, QueryMsg};
 
 use crate::{
@@ -73,10 +73,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         QueryMsg::EstimateProvideLiquidity {
             lp_token_out,
             coins_in,
-        } => to_binary(&estimate_provide_liquidity(&deps, &lp_token_out, coins_in)?),
+        } => to_json_binary(&estimate_provide_liquidity(&deps, &lp_token_out, coins_in)?),
         QueryMsg::EstimateWithdrawLiquidity {
             coin_in,
-        } => to_binary(&estimate_withdraw_liquidity(deps.storage, &coin_in)?),
+        } => to_json_binary(&estimate_withdraw_liquidity(deps.storage, &coin_in)?),
     };
     res.map_err(Into::into)
 }

--- a/integration-tests/tests/test_oracles.rs
+++ b/integration-tests/tests/test_oracles.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, time::SystemTime};
 
-use cosmwasm_std::{coin, to_binary, Coin, Decimal, Empty, Isqrt, Uint128};
+use cosmwasm_std::{coin, to_json_binary, Coin, Decimal, Empty, Isqrt, Uint128};
 use helpers::osmosis::instantiate_stride_contract;
 use mars_oracle_base::ContractError;
 use mars_oracle_osmosis::{
@@ -1059,7 +1059,7 @@ fn query_lsd_price() {
     let rr_attr = ica_oracle::state::RedemptionRateAttributes {
         sttoken_denom: "stuosmo".to_string(),
     };
-    let rr_attr_bin = to_binary(&rr_attr).unwrap();
+    let rr_attr_bin = to_json_binary(&rr_attr).unwrap();
     let rr_value = Decimal::from_str("1.123").unwrap();
     let now_sec = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
     wasm.execute(

--- a/packages/testing/src/incentives_querier.rs
+++ b/packages/testing/src/incentives_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Addr, Binary, Coin, ContractResult, QuerierResult, Uint128};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Coin, ContractResult, QuerierResult, Uint128};
 use mars_types::incentives::QueryMsg;
 
 pub struct IncentivesQuerier {
@@ -45,7 +45,7 @@ impl IncentivesQuerier {
                         amount: *amount,
                     })
                     .collect::<Vec<_>>();
-                to_binary(&unclaimed_rewards).into()
+                to_json_binary(&unclaimed_rewards).into()
             }
             _ => Err("[mock]: query not supported").into(),
         };

--- a/packages/testing/src/mars_mock_querier.rs
+++ b/packages/testing/src/mars_mock_querier.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    from_binary, from_slice,
+    from_json,
     testing::{MockQuerier, MOCK_CONTRACT_ADDR},
     Addr, Coin, Decimal, Empty, Querier, QuerierResult, QueryRequest, StdResult, SystemError,
     SystemResult, Uint128, WasmQuery,
@@ -38,7 +38,7 @@ pub struct MarsMockQuerier {
 
 impl Querier for MarsMockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        let request: QueryRequest<Empty> = match from_slice(bin_request) {
+        let request: QueryRequest<Empty> = match from_json(bin_request) {
             Ok(v) => v,
             Err(e) => {
                 return SystemResult::Err(SystemError::InvalidRequest {
@@ -214,7 +214,7 @@ impl MarsMockQuerier {
 
                 // Address Provider Queries
                 let parse_address_provider_query: StdResult<address_provider::QueryMsg> =
-                    from_binary(msg);
+                    from_json(msg);
                 if let Ok(address_provider_query) = parse_address_provider_query {
                     return mock_address_provider::handle_query(
                         &contract_addr,
@@ -223,39 +223,39 @@ impl MarsMockQuerier {
                 }
 
                 // Oracle Queries
-                let parse_oracle_query: StdResult<oracle::QueryMsg> = from_binary(msg);
+                let parse_oracle_query: StdResult<oracle::QueryMsg> = from_json(msg);
                 if let Ok(oracle_query) = parse_oracle_query {
                     return self.oracle_querier.handle_query(&contract_addr, oracle_query);
                 }
 
                 // Incentives Queries
-                let parse_incentives_query: StdResult<incentives::QueryMsg> = from_binary(msg);
+                let parse_incentives_query: StdResult<incentives::QueryMsg> = from_json(msg);
                 if let Ok(incentives_query) = parse_incentives_query {
                     return self.incentives_querier.handle_query(&contract_addr, incentives_query);
                 }
 
                 // Pyth Queries
-                if let Ok(pyth_query) = from_binary::<pyth_sdk_cw::QueryMsg>(msg) {
+                if let Ok(pyth_query) = from_json::<pyth_sdk_cw::QueryMsg>(msg) {
                     return self.pyth_querier.handle_query(&contract_addr, pyth_query);
                 }
 
                 // RedBank Queries
-                if let Ok(redbank_query) = from_binary::<red_bank::QueryMsg>(msg) {
+                if let Ok(redbank_query) = from_json::<red_bank::QueryMsg>(msg) {
                     return self.redbank_querier.handle_query(redbank_query);
                 }
 
                 // Pyth Queries
-                if let Ok(pyth_query) = from_binary::<pyth_sdk_cw::QueryMsg>(msg) {
+                if let Ok(pyth_query) = from_json::<pyth_sdk_cw::QueryMsg>(msg) {
                     return self.pyth_querier.handle_query(&contract_addr, pyth_query);
                 }
 
                 // Redemption Rate Queries
-                if let Ok(redemption_rate_query) = from_binary::<ica_oracle::msg::QueryMsg>(msg) {
+                if let Ok(redemption_rate_query) = from_json::<ica_oracle::msg::QueryMsg>(msg) {
                     return self.redemption_rate_querier.handle_query(redemption_rate_query);
                 }
 
                 // Params Queries
-                if let Ok(params_query) = from_binary::<mars_types::params::QueryMsg>(msg) {
+                if let Ok(params_query) = from_json::<mars_types::params::QueryMsg>(msg) {
                     return self.params_querier.handle_query(params_query);
                 }
 

--- a/packages/testing/src/mock_address_provider.rs
+++ b/packages/testing/src/mock_address_provider.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, QuerierResult};
+use cosmwasm_std::{to_json_binary, Addr, Binary, ContractResult, QuerierResult};
 use mars_types::address_provider::{AddressResponseItem, QueryMsg};
 
 // NOTE: Addresses here are all hardcoded as we always use those to target a specific contract
@@ -18,7 +18,7 @@ pub fn handle_query(contract_addr: &Addr, query: QueryMsg) -> QuerierResult {
                 address_type,
                 address: address_type.to_string(),
             };
-            to_binary(&res).into()
+            to_json_binary(&res).into()
         }
 
         QueryMsg::Addresses(address_types) => {
@@ -29,7 +29,7 @@ pub fn handle_query(contract_addr: &Addr, query: QueryMsg) -> QuerierResult {
                     address: address_type.to_string(),
                 })
                 .collect::<Vec<_>>();
-            to_binary(&addresses).into()
+            to_json_binary(&addresses).into()
         }
 
         _ => panic!("[mock]: Unsupported address provider query"),

--- a/packages/testing/src/oracle_querier.rs
+++ b/packages/testing/src/oracle_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, Decimal, QuerierResult};
+use cosmwasm_std::{to_json_binary, Addr, Binary, ContractResult, Decimal, QuerierResult};
 use mars_types::oracle::{PriceResponse, QueryMsg};
 
 #[derive(Default)]
@@ -18,7 +18,7 @@ impl OracleQuerier {
                 let option_price = self.prices.get(&denom);
 
                 if let Some(price) = option_price {
-                    to_binary(&PriceResponse {
+                    to_json_binary(&PriceResponse {
                         denom,
                         price: *price,
                     })

--- a/packages/testing/src/osmosis_querier.rs
+++ b/packages/testing/src/osmosis_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Binary, ContractResult, QuerierResult, SystemError};
+use cosmwasm_std::{to_json_binary, Binary, ContractResult, QuerierResult, SystemError};
 use osmosis_std::types::osmosis::{
     downtimedetector::v1beta1::{
         RecoveredSinceDowntimeOfLengthRequest, RecoveredSinceDowntimeOfLengthResponse,
@@ -79,7 +79,7 @@ impl OsmosisQuerier {
     fn handle_query_pool_request(&self, request: PoolRequest) -> QuerierResult {
         let pool_id = request.pool_id;
         let res: ContractResult<Binary> = match self.pools.get(&pool_id) {
-            Some(query_response) => to_binary(&query_response).into(),
+            Some(query_response) => to_json_binary(&query_response).into(),
             None => Err(SystemError::InvalidRequest {
                 error: format!("QueryPoolResponse is not found for pool id: {pool_id}"),
                 request: Default::default(),
@@ -96,7 +96,7 @@ impl OsmosisQuerier {
             denom_out: request.quote_asset_denom,
         };
         let res: ContractResult<Binary> = match self.spot_prices.get(&price_key) {
-            Some(query_response) => to_binary(&query_response).into(),
+            Some(query_response) => to_json_binary(&query_response).into(),
             None => Err(SystemError::InvalidRequest {
                 error: format!("QuerySpotPriceResponse is not found for price key: {price_key:?}"),
                 request: Default::default(),
@@ -116,7 +116,7 @@ impl OsmosisQuerier {
             denom_out: request.quote_asset,
         };
         let res: ContractResult<Binary> = match self.arithmetic_twap_prices.get(&price_key) {
-            Some(query_response) => to_binary(&query_response).into(),
+            Some(query_response) => to_json_binary(&query_response).into(),
             None => Err(SystemError::InvalidRequest {
                 error: format!(
                     "ArithmeticTwapToNowResponse is not found for price key: {price_key:?}"
@@ -138,7 +138,7 @@ impl OsmosisQuerier {
             denom_out: request.quote_asset,
         };
         let res: ContractResult<Binary> = match self.geometric_twap_prices.get(&price_key) {
-            Some(query_response) => to_binary(&query_response).into(),
+            Some(query_response) => to_json_binary(&query_response).into(),
             None => Err(SystemError::InvalidRequest {
                 error: format!(
                     "GeometricTwapToNowResponse is not found for price key: {price_key:?}"
@@ -158,7 +158,7 @@ impl OsmosisQuerier {
             .downtime_detector
             .get(&(request.downtime, request.recovery.unwrap().seconds as u64))
         {
-            Some(query_response) => to_binary(&query_response).into(),
+            Some(query_response) => to_json_binary(&query_response).into(),
             None => Err(SystemError::InvalidRequest {
                 error: format!(
                     "RecoveredSinceDowntimeOfLengthResponse is not found for downtime: {:?}",

--- a/packages/testing/src/params_querier.rs
+++ b/packages/testing/src/params_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Binary, Coin, ContractResult, Decimal, QuerierResult, Uint128};
+use cosmwasm_std::{to_json_binary, Binary, Coin, ContractResult, Decimal, QuerierResult, Uint128};
 use mars_types::params::{AssetParams, QueryMsg};
 
 #[derive(Default)]
@@ -13,17 +13,17 @@ pub struct ParamsQuerier {
 impl ParamsQuerier {
     pub fn handle_query(&self, query: QueryMsg) -> QuerierResult {
         let ret: ContractResult<Binary> = match query {
-            QueryMsg::TargetHealthFactor {} => to_binary(&self.target_health_factor).into(),
+            QueryMsg::TargetHealthFactor {} => to_json_binary(&self.target_health_factor).into(),
             QueryMsg::AssetParams {
                 denom,
             } => match self.params.get(&denom) {
-                Some(params) => to_binary(&params).into(),
+                Some(params) => to_json_binary(&params).into(),
                 None => Err(format!("[mock]: could not find the params for {denom}")).into(),
             },
             QueryMsg::TotalDeposit {
                 denom,
             } => match self.total_deposits.get(&denom) {
-                Some(amount) => to_binary(&Coin {
+                Some(amount) => to_json_binary(&Coin {
                     denom,
                     amount: *amount,
                 })

--- a/packages/testing/src/pyth_querier.rs
+++ b/packages/testing/src/pyth_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, QuerierResult};
+use cosmwasm_std::{to_json_binary, Addr, Binary, ContractResult, QuerierResult};
 use pyth_sdk_cw::{PriceFeedResponse, PriceIdentifier, QueryMsg};
 
 #[derive(Default)]
@@ -17,7 +17,7 @@ impl PythQuerier {
                 let option_price = self.prices.get(&id);
 
                 if let Some(price) = option_price {
-                    to_binary(price).into()
+                    to_json_binary(price).into()
                 } else {
                     Err(format!("[mock]: could not find Pyth price for {id}")).into()
                 }

--- a/packages/testing/src/red_bank_querier.rs
+++ b/packages/testing/src/red_bank_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Binary, ContractResult, QuerierResult};
+use cosmwasm_std::{to_json_binary, Binary, ContractResult, QuerierResult};
 use mars_types::red_bank::{
     Market, QueryMsg, UserCollateralResponse, UserDebtResponse, UserPositionResponse,
 };
@@ -20,28 +20,28 @@ impl RedBankQuerier {
                 denom,
             } => {
                 let maybe_market = self.markets.get(&denom);
-                to_binary(&maybe_market).into()
+                to_json_binary(&maybe_market).into()
             }
             QueryMsg::UserCollateral {
                 user,
                 account_id: _,
                 denom,
             } => match self.users_denoms_collaterals.get(&(user.clone(), denom)) {
-                Some(collateral) => to_binary(&collateral).into(),
+                Some(collateral) => to_json_binary(&collateral).into(),
                 None => Err(format!("[mock]: could not find the collateral for {user}")).into(),
             },
             QueryMsg::UserDebt {
                 user,
                 denom,
             } => match self.users_denoms_debts.get(&(user.clone(), denom)) {
-                Some(debt) => to_binary(&debt).into(),
+                Some(debt) => to_json_binary(&debt).into(),
                 None => Err(format!("[mock]:  could not find the debt for {user}")).into(),
             },
             QueryMsg::UserPosition {
                 user,
                 account_id: _,
             } => match self.users_positions.get(&user) {
-                Some(market) => to_binary(&market).into(),
+                Some(market) => to_json_binary(&market).into(),
                 None => Err(format!("[mock]: could not find the position for {user}")).into(),
             },
             _ => Err("[mock]: Unsupported red_bank query".to_string()).into(),

--- a/packages/testing/src/redemption_rate_querier.rs
+++ b/packages/testing/src/redemption_rate_querier.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmwasm_std::{to_binary, Binary, ContractResult, QuerierResult};
+use cosmwasm_std::{to_json_binary, Binary, ContractResult, QuerierResult};
 use ica_oracle::msg::{QueryMsg, RedemptionRateResponse};
 
 #[derive(Default)]
@@ -18,7 +18,7 @@ impl RedemptionRateQuerier {
                 let option_rr = self.redemption_rates.get(&denom);
 
                 if let Some(rr) = option_rr {
-                    to_binary(rr).into()
+                    to_json_binary(rr).into()
                 } else {
                     Err(format!("[mock]: could not find redemption rate for denom {}", denom))
                         .into()

--- a/packages/testing/src/wasm_oracle.rs
+++ b/packages/testing/src/wasm_oracle.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use astroport::{
     factory::PairType, pair::StablePoolParams, pair_concentrated::ConcentratedPoolParams,
 };
-use cosmwasm_std::{to_binary, Binary, Decimal, Empty, Uint128};
+use cosmwasm_std::{to_json_binary, Binary, Decimal, Empty, Uint128};
 #[cfg(feature = "osmosis-test-tube")]
 use cw_it::Artifact;
 use cw_it::{
@@ -342,7 +342,7 @@ pub fn astro_init_params(pair_type: &PairType) -> Option<Binary> {
     match pair_type {
         PairType::Xyk {} => None,
         PairType::Stable {} => Some(
-            to_binary(&StablePoolParams {
+            to_json_binary(&StablePoolParams {
                 amp: 10,
                 owner: None,
             })
@@ -350,7 +350,7 @@ pub fn astro_init_params(pair_type: &PairType) -> Option<Binary> {
         ),
         PairType::Custom(custom) if custom == "concentrated" => Some(
             // {"amp":"500","gamma":"0.000001","mid_fee":"0.003","out_fee":"0.0045","fee_gamma":"0.01","repeg_profit_threshold":"0.00000001","min_price_scale_delta":"0.0000055","price_scale":"1.198144288063828944","ma_half_time":600,"track_asset_balances":false}
-            to_binary(&ConcentratedPoolParams {
+            to_json_binary(&ConcentratedPoolParams {
                 amp: Decimal::from_atomics(500u128, 0).unwrap(),
                 gamma: Decimal::from_atomics(1u128, 6).unwrap(),
                 mid_fee: Decimal::from_atomics(3u128, 3).unwrap(),

--- a/packages/testing/src/wasm_oracle.rs
+++ b/packages/testing/src/wasm_oracle.rs
@@ -349,13 +349,13 @@ pub fn astro_init_params(pair_type: &PairType) -> Option<Binary> {
             .unwrap(),
         ),
         PairType::Custom(custom) if custom == "concentrated" => Some(
-            // {"amp":"500","gamma":"0.00000001","mid_fee":"0.0003","out_fee":"0.0045","fee_gamma":"0.3","repeg_profit_threshold":"0.00000001","min_price_scale_delta":"0.0000055","price_scale":"1.198144288063828944","ma_half_time":600,"track_asset_balances":false}
+            // {"amp":"500","gamma":"0.000001","mid_fee":"0.003","out_fee":"0.0045","fee_gamma":"0.01","repeg_profit_threshold":"0.00000001","min_price_scale_delta":"0.0000055","price_scale":"1.198144288063828944","ma_half_time":600,"track_asset_balances":false}
             to_binary(&ConcentratedPoolParams {
                 amp: Decimal::from_atomics(500u128, 0).unwrap(),
-                gamma: Decimal::from_atomics(1u128, 8).unwrap(),
-                mid_fee: Decimal::from_atomics(3u128, 4).unwrap(),
+                gamma: Decimal::from_atomics(1u128, 6).unwrap(),
+                mid_fee: Decimal::from_atomics(3u128, 3).unwrap(),
                 out_fee: Decimal::from_atomics(45u128, 4).unwrap(),
-                fee_gamma: Decimal::from_atomics(3u128, 1).unwrap(),
+                fee_gamma: Decimal::from_atomics(1u128, 2).unwrap(),
                 repeg_profit_threshold: Decimal::from_atomics(1u128, 8).unwrap(),
                 min_price_scale_delta: Decimal::from_atomics(55u128, 7).unwrap(),
                 price_scale: Decimal::from_str("1.198144288063828944").unwrap(),

--- a/packages/types/src/adapters/incentives.rs
+++ b/packages/types/src/adapters/incentives.rs
@@ -1,5 +1,7 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, Api, Coin, CosmosMsg, QuerierWrapper, StdResult, WasmMsg};
+use cosmwasm_std::{
+    to_json_binary, Addr, Api, Coin, CosmosMsg, QuerierWrapper, StdResult, WasmMsg,
+};
 
 use crate::incentives::{ExecuteMsg, QueryMsg};
 
@@ -44,7 +46,7 @@ impl Incentives {
     pub fn claim_rewards_msg(&self, account_id: &str) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.addr.to_string(),
-            msg: to_binary(&ExecuteMsg::ClaimRewards {
+            msg: to_json_binary(&ExecuteMsg::ClaimRewards {
                 account_id: Some(account_id.to_string()),
                 start_after_collateral_denom: None,
                 start_after_incentive_denom: None,

--- a/packages/types/src/adapters/red_bank.rs
+++ b/packages/types/src/adapters/red_bank.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Addr, Api, Coin, CosmosMsg, QuerierWrapper, QueryRequest, StdResult, Uint128,
+    to_json_binary, Addr, Api, Coin, CosmosMsg, QuerierWrapper, QueryRequest, StdResult, Uint128,
     WasmMsg, WasmQuery,
 };
 
@@ -50,7 +50,7 @@ impl RedBank {
     pub fn borrow_msg(&self, coin: &Coin) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.addr.to_string(),
-            msg: to_binary(&red_bank::ExecuteMsg::Borrow {
+            msg: to_json_binary(&red_bank::ExecuteMsg::Borrow {
                 denom: coin.denom.to_string(),
                 amount: coin.amount,
                 recipient: None,
@@ -63,7 +63,7 @@ impl RedBank {
     pub fn repay_msg(&self, coin: &Coin) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.addr.to_string(),
-            msg: to_binary(&red_bank::ExecuteMsg::Repay {
+            msg: to_json_binary(&red_bank::ExecuteMsg::Repay {
                 on_behalf_of: None,
             })?,
             funds: vec![coin.clone()],
@@ -74,7 +74,7 @@ impl RedBank {
     pub fn lend_msg(&self, coin: &Coin, account_id: &str) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.addr.to_string(),
-            msg: to_binary(&red_bank::ExecuteMsg::Deposit {
+            msg: to_json_binary(&red_bank::ExecuteMsg::Deposit {
                 account_id: Some(account_id.to_string()),
                 on_behalf_of: None,
             })?,
@@ -91,7 +91,7 @@ impl RedBank {
     ) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.addr.to_string(),
-            msg: to_binary(&red_bank::ExecuteMsg::Withdraw {
+            msg: to_json_binary(&red_bank::ExecuteMsg::Withdraw {
                 denom: coin.denom.clone(),
                 amount: Some(coin.amount),
                 recipient: None,
@@ -111,7 +111,7 @@ impl RedBank {
         let response: red_bank::UserCollateralResponse =
             querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
                 contract_addr: self.addr.to_string(),
-                msg: to_binary(&red_bank::QueryMsg::UserCollateral {
+                msg: to_json_binary(&red_bank::QueryMsg::UserCollateral {
                     user: self.credit_manager.to_string(),
                     account_id: Some(account_id.to_string()),
                     denom: denom.to_string(),
@@ -151,7 +151,7 @@ impl RedBank {
     ) -> StdResult<red_bank::PaginatedUserCollateralResponse> {
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: self.addr.to_string(),
-            msg: to_binary(&red_bank::QueryMsg::UserCollateralsV2 {
+            msg: to_json_binary(&red_bank::QueryMsg::UserCollateralsV2 {
                 user: self.credit_manager.to_string(),
                 account_id: Some(account_id.to_string()),
                 start_after,
@@ -164,7 +164,7 @@ impl RedBank {
         let response: red_bank::UserDebtResponse =
             querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
                 contract_addr: self.addr.to_string(),
-                msg: to_binary(&red_bank::QueryMsg::UserDebt {
+                msg: to_json_binary(&red_bank::QueryMsg::UserDebt {
                     user: self.credit_manager.to_string(),
                     denom: denom.to_string(),
                 })?,

--- a/packages/types/src/adapters/swapper.rs
+++ b/packages/types/src/adapters/swapper.rs
@@ -1,5 +1,7 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, Api, Coin, CosmosMsg, Decimal, Empty, StdResult, WasmMsg};
+use cosmwasm_std::{
+    to_json_binary, Addr, Api, Coin, CosmosMsg, Decimal, Empty, StdResult, WasmMsg,
+};
 
 use crate::swapper::{ExecuteMsg, SwapperRoute};
 
@@ -42,7 +44,7 @@ impl Swapper {
     ) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.address().to_string(),
-            msg: to_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
+            msg: to_json_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
                 coin_in: coin_in.clone(),
                 denom_out: denom_out.to_string(),
                 slippage,
@@ -113,7 +115,7 @@ mod tests {
             msg,
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "swapper".to_string(),
-                msg: to_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
+                msg: to_json_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
                     coin_in: coin_in.clone(),
                     denom_out: denom_out.to_string(),
                     slippage,
@@ -142,7 +144,7 @@ mod tests {
             msg,
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "swapper".to_string(),
-                msg: to_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
+                msg: to_json_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
                     coin_in: coin_in.clone(),
                     denom_out: denom_out.to_string(),
                     slippage,

--- a/packages/types/src/adapters/vault/base.rs
+++ b/packages/types/src/adapters/vault/base.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Addr, Api, BalanceResponse, BankQuery, Coin, CosmosMsg, QuerierWrapper,
+    to_json_binary, Addr, Api, BalanceResponse, BankQuery, Coin, CosmosMsg, QuerierWrapper,
     QueryRequest, StdResult, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw_utils::Duration;
@@ -77,7 +77,7 @@ impl Vault {
         let deposit_msg = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.address.to_string(),
             funds: vec![coin.clone()],
-            msg: to_binary(&ExecuteMsg::Deposit {
+            msg: to_json_binary(&ExecuteMsg::Deposit {
                 amount: coin.amount,
                 recipient: None,
             })?,
@@ -93,7 +93,7 @@ impl Vault {
                 denom: vault_info.vault_token,
                 amount,
             }],
-            msg: to_binary(&ExecuteMsg::Redeem {
+            msg: to_json_binary(&ExecuteMsg::Redeem {
                 recipient: None,
                 amount,
             })?,
@@ -113,7 +113,7 @@ impl Vault {
                 denom: vault_info.vault_token,
                 amount,
             }],
-            msg: to_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::ForceUnlock(
+            msg: to_json_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::ForceUnlock(
                 ForceRedeem {
                     recipient: None,
                     amount,
@@ -131,7 +131,7 @@ impl Vault {
         let withdraw_msg = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.address.to_string(),
             funds: vec![],
-            msg: to_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::ForceUnlock(
+            msg: to_json_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::ForceUnlock(
                 ForceWithdrawUnlocking {
                     lockup_id,
                     amount,
@@ -147,9 +147,11 @@ impl Vault {
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: self.address.to_string(),
                 funds: vec![coin.clone()],
-                msg: to_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::Lockup(Unlock {
-                    amount: coin.amount,
-                })))?,
+                msg: to_json_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::Lockup(
+                    Unlock {
+                        amount: coin.amount,
+                    },
+                )))?,
             }),
             VAULT_REQUEST_REPLY_ID,
         );
@@ -160,7 +162,7 @@ impl Vault {
         let withdraw_msg = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.address.to_string(),
             funds: vec![],
-            msg: to_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::Lockup(
+            msg: to_json_binary(&ExecuteMsg::VaultExtension(ExtensionExecuteMsg::Lockup(
                 WithdrawUnlocked {
                     recipient: None,
                     lockup_id,
@@ -173,14 +175,14 @@ impl Vault {
     pub fn query_info(&self, querier: &QuerierWrapper) -> StdResult<VaultInfoResponse> {
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: self.address.to_string(),
-            msg: to_binary(&QueryMsg::Info {})?,
+            msg: to_json_binary(&QueryMsg::Info {})?,
         }))
     }
 
     pub fn query_lockup_duration(&self, querier: &QuerierWrapper) -> StdResult<Duration> {
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: self.address.to_string(),
-            msg: to_binary(&QueryMsg::VaultExtension(ExtensionQueryMsg::Lockup(
+            msg: to_json_binary(&QueryMsg::VaultExtension(ExtensionQueryMsg::Lockup(
                 LockupDuration {},
             )))?,
         }))
@@ -193,7 +195,7 @@ impl Vault {
     ) -> StdResult<UnlockingPosition> {
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: self.address.to_string(),
-            msg: to_binary(&QueryMsg::VaultExtension(ExtensionQueryMsg::Lockup(
+            msg: to_json_binary(&QueryMsg::VaultExtension(ExtensionQueryMsg::Lockup(
                 LockupQueryMsg::UnlockingPosition {
                     lockup_id,
                 },
@@ -217,7 +219,7 @@ impl Vault {
     ) -> StdResult<Uint128> {
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: self.address.to_string(),
-            msg: to_binary(&QueryMsg::PreviewRedeem {
+            msg: to_json_binary(&QueryMsg::PreviewRedeem {
                 amount,
             })?,
         }))
@@ -226,7 +228,7 @@ impl Vault {
     pub fn query_total_vault_coins_issued(&self, querier: &QuerierWrapper) -> StdResult<Uint128> {
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: self.address.to_string(),
-            msg: to_binary(&QueryMsg::TotalVaultTokenSupply {})?,
+            msg: to_json_binary(&QueryMsg::TotalVaultTokenSupply {})?,
         }))
     }
 }

--- a/packages/types/src/adapters/zapper.rs
+++ b/packages/types/src/adapters/zapper.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Addr, Api, Coin, CosmosMsg, QuerierWrapper, StdResult, Uint128, WasmMsg,
+    to_json_binary, Addr, Api, Coin, CosmosMsg, QuerierWrapper, StdResult, Uint128, WasmMsg,
 };
 
 use crate::zapper::{ExecuteMsg, QueryMsg};
@@ -70,7 +70,7 @@ impl Zapper {
     ) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.address().to_string(),
-            msg: to_binary(&ExecuteMsg::ProvideLiquidity {
+            msg: to_json_binary(&ExecuteMsg::ProvideLiquidity {
                 lp_token_out: lp_token_out.to_string(),
                 minimum_receive,
                 recipient: None,
@@ -86,7 +86,7 @@ impl Zapper {
     ) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: self.address().to_string(),
-            msg: to_binary(&ExecuteMsg::WithdrawLiquidity {
+            msg: to_json_binary(&ExecuteMsg::WithdrawLiquidity {
                 recipient: None,
                 minimum_receive,
             })?,

--- a/packages/types/src/credit_manager/execute.rs
+++ b/packages/types/src/credit_manager/execute.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Decimal, StdResult, Uint128, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, Decimal, StdResult, Uint128, WasmMsg};
 use mars_owner::OwnerUpdate;
 
 use super::ConfigUpdates;
@@ -360,7 +360,7 @@ impl CallbackMsg {
     pub fn into_cosmos_msg(&self, contract_addr: &Addr) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: contract_addr.to_string(),
-            msg: to_binary(&ExecuteMsg::Callback(self.clone()))?,
+            msg: to_json_binary(&ExecuteMsg::Callback(self.clone()))?,
             funds: vec![],
         }))
     }

--- a/packages/types/src/zapper.rs
+++ b/packages/types/src/zapper.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Env, StdResult, Uint128, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, Env, StdResult, Uint128, WasmMsg};
 
 #[cw_serde]
 pub struct InstantiateMsg {}
@@ -30,7 +30,7 @@ impl CallbackMsg {
     pub fn into_cosmos_msg(self, env: &Env) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: env.contract.address.to_string(),
-            msg: to_binary(&ExecuteMsg::Callback(self))?,
+            msg: to_json_binary(&ExecuteMsg::Callback(self))?,
             funds: vec![],
         }))
     }

--- a/schema.Makefile.toml
+++ b/schema.Makefile.toml
@@ -5,8 +5,8 @@ use std::fs;
 use std::process::Command;
 
 fn main() -> std::io::Result<()> {
-    fs::remove_dir_all("schema");
-    fs::remove_dir_all("schemas");
+    let _ = fs::remove_dir_all("schema");
+    let _ = fs::remove_dir_all("schemas");
     fs::create_dir("schemas")?;
     println!("Done");
 
@@ -53,7 +53,7 @@ fn main() -> std::io::Result<()> {
         )?;
     }
 
-    fs::remove_dir_all("schema");
+    let _ = fs::remove_dir_all("schema");
 
     Ok(())
 }


### PR DESCRIPTION
- bump deps excluding `cw-dex` (latest version has deprecated warnings, Apollo works on new separate crates for Osmosis and Astroport dex)
- fix builds