### PR TITLE
Support osmo cosmwasm pool

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,4 @@
 [advisories]
 # Ignore the following advisory IDs.
 # Reported vulnerabilities relate to test-tube which is only used for testing.
-ignore = ["RUSTSEC-2024-0003", "RUSTSEC-2024-0006"]
+ignore = ["RUSTSEC-2024-0003", "RUSTSEC-2024-0006", "RUSTSEC-2024-0019"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,8 @@ dependencies = [
  "mars-testing",
  "mars-types",
  "osmosis-std 0.22.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mars-swapper-osmosis"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,7 @@ dependencies = [
  "pyth-sdk-cw",
  "schemars",
  "serde",
+ "serde_json",
  "test-case",
 ]
 
@@ -2358,6 +2359,7 @@ dependencies = [
  "osmosis-std 0.22.0",
  "prost 0.12.3",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,7 +2328,6 @@ dependencies = [
  "pyth-sdk-cw",
  "schemars",
  "serde",
- "serde_json",
  "test-case",
 ]
 
@@ -2359,7 +2358,6 @@ dependencies = [
  "osmosis-std 0.22.0",
  "prost 0.12.3",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2619,7 +2617,6 @@ dependencies = [
  "mars-types",
  "osmosis-std 0.22.0",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
 name = "mars-osmosis"
 version = "2.0.0"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "osmosis-std 0.22.0",
  "prost 0.12.3",

--- a/contracts/oracle/osmosis/Cargo.toml
+++ b/contracts/oracle/osmosis/Cargo.toml
@@ -40,5 +40,4 @@ cosmwasm-schema = { workspace = true }
 mars-owner      = { workspace = true }
 mars-testing    = { workspace = true }
 mars-utils      = { workspace = true }
-serde_json      = { workspace = true }
 test-case       = { workspace = true }

--- a/contracts/oracle/osmosis/Cargo.toml
+++ b/contracts/oracle/osmosis/Cargo.toml
@@ -40,4 +40,5 @@ cosmwasm-schema = { workspace = true }
 mars-owner      = { workspace = true }
 mars-testing    = { workspace = true }
 mars-utils      = { workspace = true }
+serde_json      = { workspace = true }
 test-case       = { workspace = true }

--- a/contracts/oracle/osmosis/src/helpers.rs
+++ b/contracts/oracle/osmosis/src/helpers.rs
@@ -26,6 +26,7 @@ pub fn assert_osmosis_pool_assets(
         }
         Pool::StableSwap(_) => {}
         Pool::ConcentratedLiquidity(_) => {}
+        Pool::CosmWasm(_) => {}
     };
 
     Ok(())
@@ -45,6 +46,11 @@ pub fn assert_osmosis_xyk_lp_pool(pool: &Pool) -> ContractResult<()> {
         Pool::ConcentratedLiquidity(cl_pool) => {
             return Err(ContractError::InvalidPriceSource {
                 reason: format!("ConcentratedLiquidity pool not supported. Pool id {}", cl_pool.id),
+            });
+        }
+        Pool::CosmWasm(cw_pool) => {
+            return Err(ContractError::InvalidPriceSource {
+                reason: format!("CosmWasm pool not supported. Pool id {}", cw_pool.id),
             });
         }
     };

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -624,6 +624,11 @@ impl OsmosisPriceSourceChecked {
                     ),
                 })
             }
+            Pool::CosmWasm(pool) => {
+                return Err(ContractError::InvalidPrice {
+                    reason: format!("CosmWasm pool not supported. Pool id {}", pool.id),
+                })
+            }
         };
 
         let coin0 = Pool::unwrap_coin(&pool.pool_assets[0].token)?;

--- a/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, str::FromStr};
 use cosmwasm_std::{
     coin, from_json,
     testing::{mock_env, MockApi, MockQuerier, MockStorage},
-    Coin, Decimal, Deps, DepsMut, OwnedDeps,
+    to_json_vec, Coin, Decimal, Deps, DepsMut, OwnedDeps,
 };
 use mars_oracle_base::ContractError;
 use mars_oracle_osmosis::{contract::entry, msg::ExecuteMsg, OsmosisPriceSourceUnchecked};
@@ -257,7 +257,7 @@ pub fn prepare_query_cosmwasm_pool_response(
             .to_string(),
         pool_id,
         code_id: 148,
-        instantiate_msg: serde_json::to_vec(&msg).unwrap(),
+        instantiate_msg: to_json_vec(&msg).unwrap(),
     };
     PoolResponse {
         pool: Some(pool.to_any()),

--- a/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
@@ -12,7 +12,11 @@ use mars_oracle_osmosis::{contract::entry, msg::ExecuteMsg, OsmosisPriceSourceUn
 use mars_osmosis::{BalancerPool, ConcentratedLiquidityPool, StableSwapPool};
 use mars_testing::{mock_info, MarsMockQuerier};
 use mars_types::oracle::{InstantiateMsg, QueryMsg};
-use osmosis_std::types::osmosis::{gamm::v1beta1::PoolAsset, poolmanager::v1beta1::PoolResponse};
+use osmosis_std::types::osmosis::{
+    cosmwasmpool::v1beta1::{CosmWasmPool, InstantiateMsg as CosmwasmPoolInstantiateMsg},
+    gamm::v1beta1::PoolAsset,
+    poolmanager::v1beta1::PoolResponse,
+};
 use pyth_sdk_cw::PriceIdentifier;
 
 pub fn setup_test_with_pools() -> OwnedDeps<MockStorage, MockApi, MarsMockQuerier> {
@@ -99,6 +103,12 @@ pub fn setup_test_with_pools() -> OwnedDeps<MockStorage, MockApi, MarsMockQuerie
     // Set ConcentratedLiquidity pool
     deps.querier
         .set_query_pool_response(7777, prepare_query_cl_pool_response(7777, "ujuno", "uosmo"));
+
+    // Set CosmWasm pool
+    deps.querier.set_query_pool_response(
+        8888,
+        prepare_query_cosmwasm_pool_response(8888, "uausdc", "unusdc"),
+    );
 
     deps
 }
@@ -228,6 +238,26 @@ pub fn prepare_query_cl_pool_response(pool_id: u64, token0: &str, token1: &str) 
         exponent_at_price_one: -6,
         spread_factor: "0.002000000000000000".to_string(),
         last_liquidity_update: None,
+    };
+    PoolResponse {
+        pool: Some(pool.to_any()),
+    }
+}
+
+pub fn prepare_query_cosmwasm_pool_response(
+    pool_id: u64,
+    token0: &str,
+    token1: &str,
+) -> PoolResponse {
+    let msg = CosmwasmPoolInstantiateMsg {
+        pool_asset_denoms: vec![token0.to_string(), token1.to_string()],
+    };
+    let pool = CosmWasmPool {
+        contract_address: "osmo10c8y69yylnlwrhu32ralf08ekladhfknfqrjsy9yqc9ml8mlxpqq2sttzk"
+            .to_string(),
+        pool_id,
+        code_id: 148,
+        instantiate_msg: serde_json::to_vec(&msg).unwrap(),
     };
     PoolResponse {
         pool: Some(pool.to_any()),

--- a/contracts/oracle/osmosis/tests/tests/test_set_price_source.rs
+++ b/contracts/oracle/osmosis/tests/tests/test_set_price_source.rs
@@ -1038,6 +1038,15 @@ fn setting_price_source_xyk_lp() {
         }
     );
 
+    // attempting to use CosmWasm pool
+    let err = set_price_source_xyk_lp("uausdc_unusdc_lp", 8888).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "CosmWasm pool not supported. Pool id 8888".to_string()
+        }
+    );
+
     // properly set xyk lp price source
     let res = set_price_source_xyk_lp("uosmo_umars_lp", 89).unwrap();
     assert_eq!(res.messages.len(), 0);

--- a/contracts/swapper/osmosis/Cargo.toml
+++ b/contracts/swapper/osmosis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "mars-swapper-osmosis"
-version       = "2.0.1"
+version       = "2.0.2"
 authors       = { workspace = true }
 license       = { workspace = true }
 edition       = { workspace = true }

--- a/contracts/swapper/osmosis/Cargo.toml
+++ b/contracts/swapper/osmosis/Cargo.toml
@@ -35,4 +35,3 @@ anyhow       = { workspace = true }
 cw-it        = { workspace = true, features = ["osmosis-test-tube"] }
 mars-testing = { workspace = true }
 serde        = { workspace = true }
-serde_json   = { workspace = true }

--- a/contracts/swapper/osmosis/Cargo.toml
+++ b/contracts/swapper/osmosis/Cargo.toml
@@ -34,3 +34,5 @@ osmosis-std       = { workspace = true }
 anyhow       = { workspace = true }
 cw-it        = { workspace = true, features = ["osmosis-test-tube"] }
 mars-testing = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }

--- a/contracts/swapper/osmosis/src/contract.rs
+++ b/contracts/swapper/osmosis/src/contract.rs
@@ -41,6 +41,6 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
     match msg {
         MigrateMsg::V1_0_0ToV2_0_0 {} => migrations::v2_0_0::migrate(deps),
-        MigrateMsg::V2_0_0ToV2_0_1 {} => migrations::v2_0_1::migrate(deps),
+        MigrateMsg::V2_0_1ToV2_0_2 {} => migrations::v2_0_2::migrate(deps),
     }
 }

--- a/contracts/swapper/osmosis/src/migrations/mod.rs
+++ b/contracts/swapper/osmosis/src/migrations/mod.rs
@@ -1,2 +1,2 @@
 pub mod v2_0_0;
-pub mod v2_0_1;
+pub mod v2_0_2;

--- a/contracts/swapper/osmosis/src/migrations/v2_0_2.rs
+++ b/contracts/swapper/osmosis/src/migrations/v2_0_2.rs
@@ -4,7 +4,7 @@ use mars_swapper_base::ContractError;
 
 use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
 
-const FROM_VERSION: &str = "2.0.0";
+const FROM_VERSION: &str = "2.0.1";
 
 pub fn migrate(deps: DepsMut) -> Result<Response, ContractError> {
     // make sure we're migrating the correct contract and from the correct version

--- a/contracts/swapper/osmosis/src/route.rs
+++ b/contracts/swapper/osmosis/src/route.rs
@@ -202,10 +202,10 @@ fn query_out_amount(
     let mut denom_in = coin_in.denom.clone();
     for step in steps {
         let pool = query_pool(querier, step.pool_id)?;
-        let step_price = if let Pool::CosmWasm(..) = pool {
+        let step_price = if let Pool::CosmWasm(cw_pool) = pool {
             // TWAP not supported.
-            // This is transmuter (https://github.com/osmosis-labs/transmuter) pool with 1:1 conversion of one asset to another.
-            Decimal::one()
+            // This is transmuter (https://github.com/osmosis-labs/transmuter) pool.
+            cw_pool.query_price(&denom_in, &step.token_out_denom)?
         } else {
             query_arithmetic_twap_price(
                 querier,

--- a/contracts/swapper/osmosis/tests/tests/test_estimate.rs
+++ b/contracts/swapper/osmosis/tests/tests/test_estimate.rs
@@ -1,11 +1,26 @@
-use cosmwasm_std::{coin, Uint128};
+use std::{marker::PhantomData, str::FromStr};
+
+use cosmwasm_std::{
+    coin, from_json,
+    testing::{mock_env, MockApi, MockQuerier, MockStorage},
+    Decimal, OwnedDeps, Uint128,
+};
 use cw_it::osmosis_test_tube::{Gamm, Module, OsmosisTestApp, RunnerResult, Wasm};
+use mars_osmosis::ConcentratedLiquidityPool;
 use mars_swapper_osmosis::{
     config::OsmosisConfig,
+    contract::{instantiate, query},
     route::{OsmosisRoute, SwapAmountInRoute},
 };
+use mars_testing::{mock_info, MarsMockQuerier};
 use mars_types::swapper::{
-    EstimateExactInSwapResponse, ExecuteMsg, OsmoRoute, OsmoSwap, QueryMsg, SwapperRoute,
+    EstimateExactInSwapResponse, ExecuteMsg, InstantiateMsg, OsmoRoute, OsmoSwap, QueryMsg,
+    SwapperRoute,
+};
+use osmosis_std::types::osmosis::{
+    cosmwasmpool::v1beta1::{CosmWasmPool, InstantiateMsg as CosmwasmPoolInstantiateMsg},
+    poolmanager::v1beta1::PoolResponse,
+    twap::v1beta1::ArithmeticTwapToNowResponse,
 };
 
 use super::helpers::{
@@ -292,4 +307,107 @@ fn estimate_swap_multi_step() {
         )
         .unwrap();
     assert_eq!(res.amount, expected_output);
+}
+
+#[test]
+fn estimate_swap_multi_step_with_cosmwasm_pool() {
+    let mut deps = OwnedDeps::<_, _, _> {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: MarsMockQuerier::new(MockQuerier::new(&[])),
+        custom_query_type: PhantomData,
+    };
+
+    // instantiate the swapper contract
+    instantiate(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("owner"),
+        InstantiateMsg {
+            owner: "owner".to_string(),
+        },
+    )
+    .unwrap();
+
+    let atom = "uatom".to_string();
+    let noble_usdc = "unusdc".to_string();
+    let axl_usdc = "uausdc".to_string();
+
+    // prepare ConcentratedLiquidity pool
+    let cl_pool_id = 1251;
+    let pool = ConcentratedLiquidityPool {
+        address: "osmo126pr9qp44aft4juw7x4ev4s2qdtnwe38jzwunec9pxt5cpzaaphqyagqpu".to_string(),
+        incentives_address: "osmo1h2mhtj3wmsdt3uacev9pgpg38hkcxhsmyyn9ums0ya6eddrsafjsxs9j03"
+            .to_string(),
+        spread_rewards_address: "osmo16j5sssw32xuk8a0kjj8n54g25ye6kr339nz5axf8lzyeajk0k22stsm36c"
+            .to_string(),
+        id: cl_pool_id,
+        current_tick_liquidity: "3820025893854099618.699762490947860933".to_string(),
+        token0: atom.clone(),
+        token1: noble_usdc.clone(),
+        current_sqrt_price: "656651.537483144215151633465586753226461989".to_string(),
+        current_tick: 102311912,
+        tick_spacing: 100,
+        exponent_at_price_one: -6,
+        spread_factor: "0.002000000000000000".to_string(),
+        last_liquidity_update: None,
+    };
+    let cl_pool = PoolResponse {
+        pool: Some(pool.to_any()),
+    };
+
+    // prepare CosmWasm (transmuter) pool
+    let cw_pool_id = 1212;
+    let msg = CosmwasmPoolInstantiateMsg {
+        pool_asset_denoms: vec![axl_usdc.clone(), noble_usdc.clone()],
+    };
+    let pool = CosmWasmPool {
+        contract_address: "osmo10c8y69yylnlwrhu32ralf08ekladhfknfqrjsy9yqc9ml8mlxpqq2sttzk"
+            .to_string(),
+        pool_id: cw_pool_id,
+        code_id: 148,
+        instantiate_msg: serde_json::to_vec(&msg).unwrap(),
+    };
+    let cw_pool = PoolResponse {
+        pool: Some(pool.to_any()),
+    };
+
+    deps.querier.set_query_pool_response(cl_pool_id, cl_pool);
+    deps.querier.set_query_pool_response(cw_pool_id, cw_pool);
+
+    // set arithmetic twap price for the ConcentratedLiquidity pool
+    deps.querier.set_arithmetic_twap_price(
+        cl_pool_id,
+        &atom,
+        &noble_usdc,
+        ArithmeticTwapToNowResponse {
+            arithmetic_twap: Decimal::from_str("11.5").unwrap().to_string(),
+        },
+    );
+
+    // check the estimate swap output
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::EstimateExactInSwap {
+            coin_in: coin(1250, &atom),
+            denom_out: axl_usdc.clone(),
+            route: Some(SwapperRoute::Osmo(OsmoRoute {
+                swaps: vec![
+                    OsmoSwap {
+                        pool_id: cl_pool_id,
+                        to: noble_usdc,
+                    },
+                    OsmoSwap {
+                        pool_id: cw_pool_id,
+                        to: axl_usdc,
+                    },
+                ],
+            })),
+        },
+    )
+    .unwrap();
+    let res: EstimateExactInSwapResponse = from_json(res).unwrap();
+    // 1250 * 11.5 * 1 = 14375
+    assert_eq!(res.amount, Uint128::from(14375u128));
 }

--- a/contracts/swapper/osmosis/tests/tests/test_estimate.rs
+++ b/contracts/swapper/osmosis/tests/tests/test_estimate.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, str::FromStr};
 use cosmwasm_std::{
     coin, from_json,
     testing::{mock_env, MockApi, MockQuerier, MockStorage},
-    Decimal, OwnedDeps, Uint128,
+    to_json_vec, Decimal, OwnedDeps, Uint128,
 };
 use cw_it::osmosis_test_tube::{Gamm, Module, OsmosisTestApp, RunnerResult, Wasm};
 use mars_osmosis::ConcentratedLiquidityPool;
@@ -366,7 +366,7 @@ fn estimate_swap_multi_step_with_cosmwasm_pool() {
             .to_string(),
         pool_id: cw_pool_id,
         code_id: 148,
-        instantiate_msg: serde_json::to_vec(&msg).unwrap(),
+        instantiate_msg: to_json_vec(&msg).unwrap(),
     };
     let cw_pool = PoolResponse {
         pool: Some(pool.to_any()),

--- a/contracts/swapper/osmosis/tests/tests/test_migration_v2.rs
+++ b/contracts/swapper/osmosis/tests/tests/test_migration_v2.rs
@@ -64,12 +64,12 @@ fn successful_migration() {
     assert!(res.data.is_none());
     assert_eq!(
         res.attributes,
-        vec![attr("action", "migrate"), attr("from_version", "1.0.0"), attr("to_version", "2.0.1")] // to_version should be 2.0.0 but because of global current version in Cargo.toml is different
+        vec![attr("action", "migrate"), attr("from_version", "1.0.0"), attr("to_version", "2.0.2")] // to_version should be 2.0.0 but because of global current version in Cargo.toml is different
     );
 
     let new_contract_version = ContractVersion {
         contract: "crates.io:mars-swapper-osmosis".to_string(),
-        version: "2.0.1".to_string(), // should be 2.0.0 but global current version in Cargo.toml is different
+        version: "2.0.2".to_string(), // should be 2.0.0 but global current version in Cargo.toml is different
     };
     assert_eq!(cw2::get_contract_version(deps.as_ref().storage).unwrap(), new_contract_version);
 
@@ -85,22 +85,22 @@ fn successful_migration() {
 #[test]
 fn successful_migration_to_v2_0_2() {
     let mut deps = mock_dependencies(&[]);
-    cw2::set_contract_version(deps.as_mut().storage, "crates.io:mars-swapper-osmosis", "2.0.0")
+    cw2::set_contract_version(deps.as_mut().storage, "crates.io:mars-swapper-osmosis", "2.0.1")
         .unwrap();
 
-    let res = migrate(deps.as_mut(), mock_env(), MigrateMsg::V2_0_0ToV2_0_1 {}).unwrap();
+    let res = migrate(deps.as_mut(), mock_env(), MigrateMsg::V2_0_1ToV2_0_2 {}).unwrap();
 
     assert_eq!(res.messages, vec![]);
     assert_eq!(res.events, vec![] as Vec<Event>);
     assert!(res.data.is_none());
     assert_eq!(
         res.attributes,
-        vec![attr("action", "migrate"), attr("from_version", "2.0.0"), attr("to_version", "2.0.1")]
+        vec![attr("action", "migrate"), attr("from_version", "2.0.1"), attr("to_version", "2.0.2")]
     );
 
     let new_contract_version = ContractVersion {
         contract: "crates.io:mars-swapper-osmosis".to_string(),
-        version: "2.0.1".to_string(),
+        version: "2.0.2".to_string(),
     };
     assert_eq!(cw2::get_contract_version(deps.as_ref().storage).unwrap(), new_contract_version);
 }

--- a/packages/chains/osmosis/Cargo.toml
+++ b/packages/chains/osmosis/Cargo.toml
@@ -18,7 +18,8 @@ doctest = false
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { workspace = true }
-osmosis-std  = { workspace = true }
-serde        = { workspace = true }
-prost        = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cosmwasm-schema = { workspace = true }
+osmosis-std     = { workspace = true }
+serde           = { workspace = true }
+prost           = { workspace = true }

--- a/packages/chains/osmosis/Cargo.toml
+++ b/packages/chains/osmosis/Cargo.toml
@@ -21,4 +21,5 @@ backtraces = ["cosmwasm-std/backtraces"]
 cosmwasm-std = { workspace = true }
 osmosis-std  = { workspace = true }
 serde        = { workspace = true }
+serde_json   = { workspace = true }
 prost        = { workspace = true }

--- a/packages/chains/osmosis/Cargo.toml
+++ b/packages/chains/osmosis/Cargo.toml
@@ -21,5 +21,4 @@ backtraces = ["cosmwasm-std/backtraces"]
 cosmwasm-std = { workspace = true }
 osmosis-std  = { workspace = true }
 serde        = { workspace = true }
-serde_json   = { workspace = true }
 prost        = { workspace = true }

--- a/packages/chains/osmosis/src/helpers.rs
+++ b/packages/chains/osmosis/src/helpers.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use cosmwasm_std::{
-    coin, Decimal, Empty, QuerierWrapper, QueryRequest, StdError, StdResult, Uint128,
+    coin, from_json, Decimal, Empty, QuerierWrapper, QueryRequest, StdError, StdResult, Uint128,
 };
 use osmosis_std::{
     shim::{Duration, Timestamp},
@@ -88,7 +88,7 @@ impl TryFrom<osmosis_std::shim::Any> for Pool {
         }
 
         if let Ok(pool) = OsmoCosmWasmPool::decode(value.value.as_slice()) {
-            if let Ok(msg) = serde_json::from_slice::<InstantiateMsg>(&pool.instantiate_msg) {
+            if let Ok(msg) = from_json::<InstantiateMsg>(&pool.instantiate_msg) {
                 return Ok(Pool::CosmWasm(CosmWasmPool {
                     id: pool.pool_id,
                     denoms: msg.pool_asset_denoms,
@@ -212,6 +212,7 @@ pub fn recovered_since_downtime_of_length(
 
 #[cfg(test)]
 mod tests {
+    use cosmwasm_std::to_json_vec;
     use osmosis_std::types::osmosis::gamm::v1beta1::PoolAsset;
 
     use super::*;
@@ -359,7 +360,7 @@ mod tests {
             contract_address: "pool_address".to_string(),
             pool_id: 1212,
             code_id: 148,
-            instantiate_msg: serde_json::to_vec(&msg).unwrap(),
+            instantiate_msg: to_json_vec(&msg).unwrap(),
         };
 
         let any_pool = cosmwasm_pool.to_any();

--- a/packages/testing/src/cosmwasm_pool_querier.rs
+++ b/packages/testing/src/cosmwasm_pool_querier.rs
@@ -1,0 +1,26 @@
+use cosmwasm_std::{to_json_binary, Binary, ContractResult, QuerierResult};
+use osmosis_std::types::{
+    cosmos::base::v1beta1::Coin,
+    osmosis::cosmwasmpool::v1beta1::{CalcOutAmtGivenInRequest, CalcOutAmtGivenInResponse},
+};
+
+#[derive(Default)]
+pub struct CosmWasmPoolQuerier {}
+
+impl CosmWasmPoolQuerier {
+    pub fn handle_query(&self, query: CalcOutAmtGivenInRequest) -> QuerierResult {
+        let res: ContractResult<Binary> = {
+            let token_in = query.calc_out_amt_given_in.clone().unwrap().token_in.unwrap();
+            let denom_out = query.calc_out_amt_given_in.unwrap().token_out_denom;
+
+            to_json_binary(&CalcOutAmtGivenInResponse {
+                token_out: Some(Coin {
+                    denom: denom_out,
+                    amount: token_in.amount,
+                }),
+            })
+            .into()
+        };
+        Ok(res).into()
+    }
+}

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -4,6 +4,7 @@ extern crate core;
 
 #[cfg(feature = "astroport")]
 pub mod astroport_swapper;
+mod cosmwasm_pool_querier;
 /// cosmwasm_std::testing overrides and custom test helpers
 mod helpers;
 mod incentives_querier;

--- a/packages/testing/src/osmosis_querier.rs
+++ b/packages/testing/src/osmosis_querier.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use cosmwasm_std::{to_json_binary, Binary, ContractResult, QuerierResult, SystemError};
 use osmosis_std::types::osmosis::{
+    cosmwasmpool::v1beta1::{ContractInfoByPoolIdRequest, ContractInfoByPoolIdResponse},
     downtimedetector::v1beta1::{
         RecoveredSinceDowntimeOfLengthRequest, RecoveredSinceDowntimeOfLengthResponse,
     },
@@ -70,6 +71,14 @@ impl OsmosisQuerier {
                 Message::decode(data.as_slice());
             if let Ok(osmosis_query) = parse_osmosis_query {
                 return Ok(self.handle_recovered_since_downtime_of_length(osmosis_query));
+            }
+        }
+
+        if path == "/osmosis.cosmwasmpool.v1beta1.Query/ContractInfoByPoolId" {
+            let parse_osmosis_query: Result<ContractInfoByPoolIdRequest, DecodeError> =
+                Message::decode(data.as_slice());
+            if let Ok(osmosis_query) = parse_osmosis_query {
+                return Ok(self.handle_cosmwasm_pool_contract_info_request(osmosis_query.pool_id));
             }
         }
 
@@ -168,6 +177,15 @@ impl OsmosisQuerier {
             })
             .into(),
         };
+        Ok(res).into()
+    }
+
+    fn handle_cosmwasm_pool_contract_info_request(&self, pool_id: u64) -> QuerierResult {
+        let res: ContractResult<Binary> = to_json_binary(&ContractInfoByPoolIdResponse {
+            contract_address: format!("pool_id_{}", pool_id),
+            code_id: pool_id,
+        })
+        .into();
         Ok(res).into()
     }
 }

--- a/packages/types/src/swapper.rs
+++ b/packages/types/src/swapper.rs
@@ -122,5 +122,5 @@ pub struct EstimateExactInSwapResponse {
 #[cw_serde]
 pub enum MigrateMsg {
     V1_0_0ToV2_0_0 {},
-    V2_0_0ToV2_0_1 {},
+    V2_0_1ToV2_0_2 {},
 }

--- a/schemas/mars-swapper-osmosis/mars-swapper-osmosis.json
+++ b/schemas/mars-swapper-osmosis/mars-swapper-osmosis.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-swapper-osmosis",
-  "contract_version": "2.0.1",
+  "contract_version": "2.0.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
- Add support for CosmWasm Pool (transmuter)
- Use 1:1 pricing (https://github.com/osmosis-labs/transmuter) for CosmWasm pool when estimating out amount. For the rest of the pools we use arithmetic TWAP.

Before/After migration:
<img width="1183" alt="Zrzut ekranu 2024-02-28 o 22 18 38" src="https://github.com/mars-protocol/contracts/assets/2192395/563bef05-e88b-4276-8ea4-77951c839b76">
