### PR TITLE
Transmuter V3 support with scaling factors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
 name = "mars-osmosis"
 version = "2.0.0"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "osmosis-std 0.22.0",
  "prost 0.12.3",

--- a/contracts/swapper/osmosis/src/route.rs
+++ b/contracts/swapper/osmosis/src/route.rs
@@ -202,10 +202,12 @@ fn query_out_amount(
     let mut denom_in = coin_in.denom.clone();
     for step in steps {
         let pool = query_pool(querier, step.pool_id)?;
-        let step_price = if let Pool::CosmWasm(..) = pool {
+        let step_price = if let Pool::CosmWasm(cw_pool) = pool {
             // TWAP not supported.
-            // This is transmuter (https://github.com/osmosis-labs/transmuter) pool with 1:1 conversion of one asset to another.
-            Decimal::one()
+            // This is transmuter (https://github.com/osmosis-labs/transmuter) pool:
+            // * v1 pool - 1:1 conversion of one asset to another,
+            // * v2 pool - use normalization factor to convert one asset to another.
+            cw_pool.query_price(&denom_in, &step.token_out_denom)?
         } else {
             query_arithmetic_twap_price(
                 querier,

--- a/packages/chains/osmosis/Cargo.toml
+++ b/packages/chains/osmosis/Cargo.toml
@@ -18,7 +18,8 @@ doctest = false
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { workspace = true }
-osmosis-std  = { workspace = true }
-serde        = { workspace = true }
-prost        = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cosmwasm-schema = { workspace = true }
+osmosis-std     = { workspace = true }
+serde           = { workspace = true }
+prost           = { workspace = true }


### PR DESCRIPTION
The only reasonable way to determine version of the transmuter pool is through `instantiate_msg` schema in Pool response:
```
osmosisd query poolmanager pool 1212 --node https://rpc.osmosis.zone:443 --chain-id osmosis-1
pool:
  '@type': /osmosis.cosmwasmpool.v1beta1.CosmWasmPool
  code_id: "148"
  contract_address: osmo10c8y69yylnlwrhu32ralf08ekladhfknfqrjsy9yqc9ml8mlxpqq2sttzk
  instantiate_msg: eyJwb29sX2Fzc2V0X2Rlbm9tcyI6IFsiaWJjL0QxODkzMzVDNkU0QTY4QjUxM0MxMEFCMjI3QkYxQzFEMzhDNzQ2NzY2Mjc4QkEzRUVCNEZCMTQxMjRGMUQ4NTgiLCJpYmMvNDk4QTA3NTFDNzk4QTBEOUEzODlBQTM2OTExMjNEQURBNTdEQUE0RkUxNjVENUM3NTg5NDUwNUI4NzZCQTZFNCJdLCJhZG1pbiI6ICJvc21vMWdteDZ4OGxudmdobnl3YXpxY3l4NTZydDA3amRhdHJhY2hxZDRhZTA3M2doYXo3cmZ5bXFsZDd5NjAifQ==
  pool_id: "1212"
```

V1 (live on Osmosis mainnet):
```
{
  "pool_asset_denoms": [
    "ibc/072E5B3D6F278B3E6A9C51D7EAD1A737148609512C5EBE8CBCB5663264A0DDB7",
    "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E"
  ]
}
```

V2 (for now only available on Osmosis testnet):
```
{
  "pool_asset_denoms": [
    "uosmo",
    "factory/osmo14eq94mckd6kp0pwnxx33ycpk762z7rum29epr3/teko02"
  ],
  "admin": "osmo14eq94mckd6kp0pwnxx33ycpk762z7rum29epr3",
  "alloyed_asset_subdenom": "teko"
}
```

V3 (no live yet, contains normalization factors):
```
/// Fields taken from Instantiate msg https://github.com/osmosis-labs/transmuter/blob/47bbb023463578937a7086ad80071196126349d9/contracts/transmuter/src/contract.rs#L74
#[cw_serde]
struct TransmuterV3InstantiateMsg {
    pub pool_asset_configs: Vec<AssetConfig>,
    pub alloyed_asset_subdenom: String,
    pub alloyed_asset_normalization_factor: Uint128,
    pub admin: Option<String>,
    pub moderator: Option<String>,
}
```

