### PR TITLE
Remove route validation for swapper.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
+checksum = "dd50718a2b6830ce9eb5d465de5a018a12e71729d66b70807ce97e6dd14f931d"
 dependencies = [
  "digest 0.10.7",
  "ecdsa 0.16.8",
@@ -764,18 +764,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
+checksum = "242e98e7a231c122e08f300d9db3262d1007b51758a8732cd6210b3e9faa4f3a"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e3a2136e2a60e8b6582f5dffca5d1a683ed77bf38537d330bc1dfccd69010"
+checksum = "7879036156092ad1c22fe0d7316efc5a5eceec2bc3906462a2560215f2a2f929"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d803bea6bd9ed61bd1ee0b4a2eb09ee20dbb539cc6e0b8795614d20952ebb1"
+checksum = "0bb57855fbfc83327f8445ae0d413b1a05ac0d68c396ab4d122b2abd7bb82cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
+checksum = "78c1556156fdf892a55cced6115968b961eaaadd6f724a2c2cb7d1e168e32dd3"
 dependencies = [
  "base64 0.21.7",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ keywords      = ["mars", "cosmos", "cosmwasm"]
 anyhow             = "1.0.80"
 astroport          = "2.8.0"
 bech32             = "0.9.1"
-cosmwasm-schema    = "1.5.3"
-cosmwasm-std       = "1.5.3"
+cosmwasm-schema    = "1.5.4"
+cosmwasm-std       = "1.5.4"
 cw2                = "1.1.2"
 cw721              = { git = "https://github.com/CosmWasm/cw-nfts/", branch = "main" }
 cw721-base         = { git = "https://github.com/CosmWasm/cw-nfts/", branch = "main", features = ["library"] }

--- a/contracts/swapper/base/src/contract.rs
+++ b/contracts/swapper/base/src/contract.rs
@@ -175,10 +175,7 @@ where
 
         // if route is not provided, use the default route from state
         let route = match route {
-            Some(route) => {
-                let route = R::from(route, config)?;
-                route
-            }
+            Some(route) => R::from(route, config)?,
             None => self.get_route(deps, &coin_in.denom, &denom_out)?,
         };
         route.estimate_exact_in_swap(&deps.querier, &env, &coin_in)
@@ -207,9 +204,7 @@ where
             Some(route) => {
                 let config = self.query_config(deps.as_ref())?;
 
-                let route = R::from(route, config)?;
-
-                route
+                R::from(route, config)?
             }
             None => self
                 .routes

--- a/contracts/swapper/base/src/contract.rs
+++ b/contracts/swapper/base/src/contract.rs
@@ -177,7 +177,6 @@ where
         let route = match route {
             Some(route) => {
                 let route = R::from(route, config)?;
-                route.validate(&deps.querier, &coin_in.denom, &denom_out)?;
                 route
             }
             None => self.get_route(deps, &coin_in.denom, &denom_out)?,
@@ -209,7 +208,6 @@ where
                 let config = self.query_config(deps.as_ref())?;
 
                 let route = R::from(route, config)?;
-                route.validate(&deps.querier, &coin_in.denom, &denom_out)?;
 
                 route
             }


### PR DESCRIPTION
We have an issue with the pool validation (dynamic routing) on the Osmosis chain for the pool https://celatone.osmosis.zone/osmosis-1/pools/1570.
Contract for the pool:
https://celatone.osmosis.zone/osmosis-1/contracts/osmo1vk3kyfdswfxn7gwprn8fmflfskvp585wm2jnku2up0u7l0l7flcqt7nfqu
Instantiate msg for the contract:
```
{
  "asset_infos": [
    {
      "native_token": {
        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
      }
    },
    {
      "native_token": {
        "denom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C"
      }
    }
  ],
  "token_code_id": 0,
  "factory_addr": "osmo1246fnsutktuqqzrru673pqwtt64n288004j5fauyuezwr54llw5sl6drp6",
  "init_params": "eyJhbXAiOiIxMCIsImdhbW1hIjoiMC4wMDAxODEyNSIsIm1pZF9mZWUiOiIwLjAwMDUiLCJvdXRfZmVlIjoiMC4wMDIiLCJmZWVfZ2FtbWEiOiIwLjAwMDIzIiwicmVwZWdfcHJvZml0X3RocmVzaG9sZCI6IjAuMDAwMDAwMiIsIm1pbl9wcmljZV9zY2FsZV9kZWx0YSI6IjAuMDAwMTQ2IiwibWFfaGFsZl90aW1lIjo2MDAsInByaWNlX3NjYWxlIjoiMy45MiJ9"
}
```
We don't support such pool in our contracts. Deserialization will fail here:
https://github.com/mars-protocol/contracts/blob/master/packages/chains/osmosis/src/helpers.rs#L128


Validating pools was logical for pre-configured routing to prevent issues during swapping if the route was incorrectly set. However, with dynamic routing on Mars smart contracts, there's no need for route validation. Instead, Osmosis/Astro DEXes will validate the route during the swap execution. Additionally, this is problematic for us because we cannot anticipate what optimal routing will be provided by Osmosis/Astro, necessitating us to ensure support for all types of pools in advance.
