### PR TITLE
MP-2371. Trade any asset

### DIFF
--- a/contracts/credit-manager/src/error.rs
+++ b/contracts/credit-manager/src/error.rs
@@ -189,4 +189,7 @@ pub enum ContractError {
 
     #[error("Debt cannot be represented by zero debt shares")]
     ZeroDebtShares,
+
+    #[error("{0} asset params not found")]
+    AssetParamsNotFound(String),
 }

--- a/contracts/credit-manager/src/hls.rs
+++ b/contracts/credit-manager/src/hls.rs
@@ -18,7 +18,10 @@ pub fn assert_hls_rules(deps: Deps, account_id: &str) -> ContractResult<Response
     }
 
     if let Some(debt) = positions.debts.first() {
-        let params = PARAMS.load(deps.storage)?.query_asset_params(&deps.querier, &debt.denom)?;
+        let params = PARAMS
+            .load(deps.storage)?
+            .query_asset_params(&deps.querier, &debt.denom)?
+            .ok_or(ContractError::AssetParamsNotFound(debt.denom.to_string()))?;
 
         // Rule #2: Debt denom must have HLS params set in the Mars-Param contract
         let Some(hls) = params.credit_manager.hls else {

--- a/contracts/credit-manager/src/liquidate.rs
+++ b/contracts/credit-manager/src/liquidate.rs
@@ -39,7 +39,9 @@ pub fn calculate_liquidation(
 
     let params = PARAMS.load(deps.storage)?;
     let target_health_factor = params.query_target_health_factor(&deps.querier)?;
-    let request_coin_params = params.query_asset_params(&deps.querier, request_coin)?;
+    let request_coin_params = params
+        .query_asset_params(&deps.querier, request_coin)?
+        .ok_or(ContractError::AssetParamsNotFound(request_coin.to_string()))?;
 
     let oracle = ORACLE.load(deps.storage)?;
     let debt_coin_price =

--- a/contracts/credit-manager/src/swap.rs
+++ b/contracts/credit-manager/src/swap.rs
@@ -7,13 +7,11 @@ use mars_types::{
 use crate::{
     error::{ContractError, ContractResult},
     state::{COIN_BALANCES, SWAPPER},
-    utils::{
-        assert_coin_is_whitelisted, assert_slippage, decrement_coin_balance, update_balance_msg,
-    },
+    utils::{assert_slippage, decrement_coin_balance, update_balance_msg},
 };
 
 pub fn swap_exact_in(
-    mut deps: DepsMut,
+    deps: DepsMut,
     env: Env,
     account_id: &str,
     coin_in: &ActionCoin,
@@ -22,8 +20,6 @@ pub fn swap_exact_in(
     route: Option<SwapperRoute>,
 ) -> ContractResult<Response> {
     assert_slippage(deps.storage, slippage)?;
-
-    assert_coin_is_whitelisted(&mut deps, denom_out)?;
 
     let coin_in_to_trade = Coin {
         denom: coin_in.denom.clone(),

--- a/contracts/credit-manager/src/utils.rs
+++ b/contracts/credit-manager/src/utils.rs
@@ -66,7 +66,7 @@ pub fn query_nft_token_owner(deps: Deps, account_id: &str) -> ContractResult<Str
 pub fn assert_coin_is_whitelisted(deps: &mut DepsMut, denom: &str) -> ContractResult<()> {
     let params = PARAMS.load(deps.storage)?;
     match params.query_asset_params(&deps.querier, denom) {
-        Ok(p) if p.credit_manager.whitelisted => Ok(()),
+        Ok(Some(p)) if p.credit_manager.whitelisted => Ok(()),
         _ => Err(ContractError::NotWhitelisted(denom.to_string())),
     }
 }

--- a/contracts/credit-manager/tests/tests/helpers/mock_entity_info.rs
+++ b/contracts/credit-manager/tests/tests/helpers/mock_entity_info.rs
@@ -96,7 +96,7 @@ pub fn ujake_info() -> CoinInfo {
     }
 }
 
-pub fn blacklisted_coin() -> CoinInfo {
+pub fn blacklisted_coin_info() -> CoinInfo {
     CoinInfo {
         denom: "uluna".to_string(),
         price: Decimal::from_str("0.01").unwrap(),

--- a/contracts/credit-manager/tests/tests/test_borrow.rs
+++ b/contracts/credit-manager/tests/tests/test_borrow.rs
@@ -5,7 +5,8 @@ use mars_credit_manager::{borrow::DEFAULT_DEBT_SHARES_PER_COIN_BORROWED, error::
 use mars_types::credit_manager::Action::{Borrow, Deposit};
 
 use super::helpers::{
-    assert_err, blacklisted_coin, uosmo_info, AccountToFund, MockEnv, DEFAULT_RED_BANK_COIN_BALANCE,
+    assert_err, blacklisted_coin_info, uosmo_info, AccountToFund, MockEnv,
+    DEFAULT_RED_BANK_COIN_BALANCE,
 };
 
 #[test]
@@ -35,7 +36,7 @@ fn only_token_owner_can_borrow() {
 
 #[test]
 fn can_only_borrow_what_is_whitelisted() {
-    let blacklisted_coin = blacklisted_coin();
+    let blacklisted_coin = blacklisted_coin_info();
 
     let user = Addr::unchecked("user");
     let mut mock = MockEnv::new().set_params(&[blacklisted_coin.clone()]).build().unwrap();

--- a/contracts/credit-manager/tests/tests/test_deposit.rs
+++ b/contracts/credit-manager/tests/tests/test_deposit.rs
@@ -3,7 +3,7 @@ use mars_credit_manager::error::ContractError::{ExtraFundsReceived, FundsMismatc
 use mars_types::credit_manager::{Action, Positions};
 
 use super::helpers::{
-    assert_err, blacklisted_coin, uatom_info, ujake_info, uosmo_info, AccountToFund, CoinInfo,
+    assert_err, blacklisted_coin_info, uatom_info, ujake_info, uosmo_info, AccountToFund, CoinInfo,
     MockEnv,
 };
 
@@ -114,7 +114,7 @@ fn deposit_but_not_enough_funds() {
 
 #[test]
 fn can_deposit_not_whitelisted_assets() {
-    let blacklisted_coin_info = blacklisted_coin();
+    let blacklisted_coin_info = blacklisted_coin_info();
     let not_listed_coin_info = ujake_info();
     let blacklisted_coin = blacklisted_coin_info.to_coin(300);
     let not_listed_coin = not_listed_coin_info.to_coin(250);

--- a/contracts/credit-manager/tests/tests/test_deposit.rs
+++ b/contracts/credit-manager/tests/tests/test_deposit.rs
@@ -149,16 +149,16 @@ fn can_deposit_not_allowed_assets() {
     )
     .unwrap();
 
-    // let res = mock.query_positions(&account_id);
-    // assert_eq!(res.deposits.len(), 2);
-    // assert_present(&res, &blacklisted_coin_info, blacklisted_coin.amount);
-    // assert_present(&res, &not_listed_coin_info, not_listed_coin.amount);
+    let res = mock.query_positions(&account_id);
+    assert_eq!(res.deposits.len(), 2);
+    assert_present(&res, &blacklisted_coin_info, blacklisted_coin.amount);
+    assert_present(&res, &not_listed_coin_info, not_listed_coin.amount);
 
-    // let coin = mock.query_balance(&mock.rover, &blacklisted_coin.denom);
-    // assert_eq!(coin.amount, blacklisted_coin.amount);
+    let coin = mock.query_balance(&mock.rover, &blacklisted_coin.denom);
+    assert_eq!(coin.amount, blacklisted_coin.amount);
 
-    // let coin = mock.query_balance(&mock.rover, &not_listed_coin.denom);
-    // assert_eq!(coin.amount, not_listed_coin.amount);
+    let coin = mock.query_balance(&mock.rover, &not_listed_coin.denom);
+    assert_eq!(coin.amount, not_listed_coin.amount);
 }
 
 #[test]

--- a/contracts/credit-manager/tests/tests/test_deposit.rs
+++ b/contracts/credit-manager/tests/tests/test_deposit.rs
@@ -113,7 +113,7 @@ fn deposit_but_not_enough_funds() {
 }
 
 #[test]
-fn can_deposit_not_allowed_assets() {
+fn can_deposit_not_whitelisted_assets() {
     let blacklisted_coin_info = blacklisted_coin();
     let not_listed_coin_info = ujake_info();
     let blacklisted_coin = blacklisted_coin_info.to_coin(300);

--- a/contracts/credit-manager/tests/tests/test_deposit.rs
+++ b/contracts/credit-manager/tests/tests/test_deposit.rs
@@ -1,7 +1,5 @@
 use cosmwasm_std::{coin, coins, Addr, Coin, Coins, Uint128};
-use mars_credit_manager::error::ContractError::{
-    ExtraFundsReceived, FundsMismatch, NotTokenOwner, NotWhitelisted,
-};
+use mars_credit_manager::error::ContractError::{ExtraFundsReceived, FundsMismatch, NotTokenOwner};
 use mars_types::credit_manager::{Action, Positions};
 
 use super::helpers::{
@@ -115,42 +113,52 @@ fn deposit_but_not_enough_funds() {
 }
 
 #[test]
-fn can_only_deposit_allowed_assets() {
-    let blacklisted_coin = blacklisted_coin();
-    let not_listed_coin = ujake_info().to_coin(234);
+fn can_deposit_not_allowed_assets() {
+    let blacklisted_coin_info = blacklisted_coin();
+    let not_listed_coin_info = ujake_info();
+    let blacklisted_coin = blacklisted_coin_info.to_coin(300);
+    let not_listed_coin = not_listed_coin_info.to_coin(250);
 
     let user = Addr::unchecked("user");
     let mut mock = MockEnv::new()
-        .set_params(&[blacklisted_coin.clone()])
+        .set_params(&[blacklisted_coin_info.clone()])
         .fund_account(AccountToFund {
             addr: user.clone(),
             funds: vec![
-                coin(300, blacklisted_coin.denom.clone()),
-                coin(300, not_listed_coin.denom.clone()),
+                coin(300, blacklisted_coin_info.denom.clone()),
+                coin(300, not_listed_coin_info.denom.clone()),
             ],
         })
         .build()
         .unwrap();
     let account_id = mock.create_credit_account(&user).unwrap();
 
-    let res = mock.update_credit_account(
+    mock.update_credit_account(
         &account_id,
         &user,
         vec![Action::Deposit(not_listed_coin.clone())],
-        &[coin(250, not_listed_coin.denom.clone())],
-    );
-    assert_err(res, NotWhitelisted(not_listed_coin.denom));
+        &[not_listed_coin.clone()],
+    )
+    .unwrap();
 
-    let res = mock.update_credit_account(
+    mock.update_credit_account(
         &account_id,
         &user,
-        vec![Action::Deposit(blacklisted_coin.to_coin(250))],
-        &[coin(250, blacklisted_coin.denom.clone())],
-    );
-    assert_err(res, NotWhitelisted(blacklisted_coin.denom));
+        vec![Action::Deposit(blacklisted_coin.clone())],
+        &[blacklisted_coin.clone()],
+    )
+    .unwrap();
 
-    let res = mock.query_positions(&account_id);
-    assert_eq!(res.deposits.len(), 0);
+    // let res = mock.query_positions(&account_id);
+    // assert_eq!(res.deposits.len(), 2);
+    // assert_present(&res, &blacklisted_coin_info, blacklisted_coin.amount);
+    // assert_present(&res, &not_listed_coin_info, not_listed_coin.amount);
+
+    // let coin = mock.query_balance(&mock.rover, &blacklisted_coin.denom);
+    // assert_eq!(coin.amount, blacklisted_coin.amount);
+
+    // let coin = mock.query_balance(&mock.rover, &not_listed_coin.denom);
+    // assert_eq!(coin.amount, not_listed_coin.amount);
 }
 
 #[test]

--- a/contracts/credit-manager/tests/tests/test_lend.rs
+++ b/contracts/credit-manager/tests/tests/test_lend.rs
@@ -8,7 +8,7 @@ use mars_types::credit_manager::{
 };
 
 use super::helpers::{
-    assert_err, blacklisted_coin, coin_info, uosmo_info, AccountToFund, MockEnv,
+    assert_err, blacklisted_coin_info, coin_info, uosmo_info, AccountToFund, MockEnv,
     DEFAULT_RED_BANK_COIN_BALANCE,
 };
 
@@ -38,7 +38,7 @@ fn only_token_owner_can_lend() {
 
 #[test]
 fn can_only_lend_what_is_whitelisted() {
-    let coin_info = blacklisted_coin();
+    let coin_info = blacklisted_coin_info();
     let user = Addr::unchecked("user");
     let mut mock = MockEnv::new().set_params(&[coin_info.clone()]).build().unwrap();
     let account_id = mock.create_credit_account(&user).unwrap();

--- a/contracts/health/src/compute.rs
+++ b/contracts/health/src/compute.rs
@@ -43,6 +43,7 @@ pub fn compute_health(
         .chain(vault_base_token_denoms)
         .try_for_each(|denom| -> StdResult<()> {
             let params_opt = q.params.query_asset_params(&deps.querier, denom)?;
+            // If the asset is not supported, we skip it (both params and price)
             if let Some(params) = params_opt {
                 denoms_data.params.insert(denom.clone(), params);
 

--- a/contracts/health/src/compute.rs
+++ b/contracts/health/src/compute.rs
@@ -42,10 +42,13 @@ pub fn compute_health(
         .chain(lend_denoms)
         .chain(vault_base_token_denoms)
         .try_for_each(|denom| -> StdResult<()> {
-            let price = q.oracle.query_price(&deps.querier, denom, action.clone())?.price;
-            denoms_data.prices.insert(denom.clone(), price);
-            let params = q.params.query_asset_params(&deps.querier, denom)?;
-            denoms_data.params.insert(denom.clone(), params);
+            let params_opt = q.params.query_asset_params(&deps.querier, denom)?;
+            if let Some(params) = params_opt {
+                denoms_data.params.insert(denom.clone(), params);
+
+                let price = q.oracle.query_price(&deps.querier, denom, action.clone())?.price;
+                denoms_data.prices.insert(denom.clone(), price);
+            }
             Ok(())
         })?;
 

--- a/contracts/health/tests/tests/test_health_values.rs
+++ b/contracts/health/tests/tests/test_health_values.rs
@@ -343,7 +343,7 @@ fn vault_whitelist_affects_max_ltv() {
 }
 
 #[test]
-fn not_supported_coins_work() {
+fn not_whitelisted_coins_work() {
     let mut mock = MockEnv::new().build().unwrap();
 
     let umars = "umars";

--- a/contracts/health/tests/tests/test_health_values.rs
+++ b/contracts/health/tests/tests/test_health_values.rs
@@ -16,6 +16,7 @@ use mars_types::{
 };
 
 use super::helpers::MockEnv;
+use crate::tests::helpers::default_asset_params;
 
 #[test]
 fn raises_when_credit_manager_not_set() {
@@ -339,4 +340,60 @@ fn vault_whitelist_affects_max_ltv() {
     let health =
         mock.query_health_values(account_id, AccountKind::Default, ActionKind::Default).unwrap();
     assert_eq!(health.max_ltv_adjusted_collateral, Uint128::zero());
+}
+
+#[test]
+fn not_supported_coins_work() {
+    let mut mock = MockEnv::new().build().unwrap();
+
+    let umars = "umars";
+    let urandom = "urandom";
+
+    mock.set_price(umars, Decimal::one(), ActionKind::Default);
+    let umars_ap = default_asset_params(umars);
+    mock.update_asset_params(AddOrUpdate {
+        params: umars_ap.clone(),
+    });
+
+    let umars_deposit_amount = Uint128::new(30);
+    let urandom_deposit_amount = Uint128::new(1200);
+
+    let account_id = "123";
+    mock.set_positions_response(
+        account_id,
+        &Positions {
+            account_id: account_id.to_string(),
+            account_kind: AccountKind::Default,
+            deposits: vec![
+                Coin {
+                    denom: umars.to_string(),
+                    amount: umars_deposit_amount,
+                },
+                Coin {
+                    denom: urandom.to_string(),
+                    amount: urandom_deposit_amount,
+                },
+            ],
+            debts: vec![],
+            lends: vec![],
+            vaults: vec![],
+        },
+    );
+
+    let health =
+        mock.query_health_values(account_id, AccountKind::Default, ActionKind::Default).unwrap();
+    assert_eq!(health.total_debt_value, Uint128::zero());
+    assert_eq!(health.total_collateral_value, umars_deposit_amount); // price of 1
+    assert_eq!(
+        health.max_ltv_adjusted_collateral,
+        umars_deposit_amount.checked_mul_floor(umars_ap.max_loan_to_value).unwrap()
+    );
+    assert_eq!(
+        health.liquidation_threshold_adjusted_collateral,
+        umars_deposit_amount.checked_mul_floor(umars_ap.liquidation_threshold).unwrap()
+    );
+    assert_eq!(health.max_ltv_health_factor, None);
+    assert_eq!(health.liquidation_health_factor, None);
+    assert!(!health.liquidatable);
+    assert!(!health.above_max_ltv);
 }

--- a/contracts/params/src/contract.rs
+++ b/contracts/params/src/contract.rs
@@ -91,7 +91,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::AssetParams {
             denom,
-        } => to_json_binary(&ASSET_PARAMS.load(deps.storage, &denom)?),
+        } => to_json_binary(&ASSET_PARAMS.may_load(deps.storage, &denom)?),
         QueryMsg::AllAssetParams {
             start_after,
             limit,

--- a/packages/health-computer/tests/tests/test_input_validation.rs
+++ b/packages/health-computer/tests/tests/test_input_validation.rs
@@ -105,8 +105,27 @@ fn missing_params() {
         vaults_data,
     };
 
-    let err: HealthError = h.compute_health().unwrap_err();
-    assert_eq!(err, HealthError::MissingParams(umars.denom))
+    // If asset params is missing for a denom (in params contract), both price and params will be missing in denoms_data.
+    // For purpose of this test, we set the price for umars, but not the params.
+    let res = h.compute_health().unwrap();
+    // mars is not counted in the collateral because it has no params
+    let expected_ltv_collateral = Uint128::new(33)
+        .checked_mul_floor(udai.price)
+        .unwrap()
+        .checked_mul_floor(udai.params.max_loan_to_value)
+        .unwrap();
+    assert_eq!(res.max_ltv_adjusted_collateral, expected_ltv_collateral);
+    let expected_liq_collateral = Uint128::new(33)
+        .checked_mul_floor(udai.price)
+        .unwrap()
+        .checked_mul_floor(udai.params.liquidation_threshold)
+        .unwrap();
+    assert_eq!(res.liquidation_threshold_adjusted_collateral, expected_liq_collateral);
+    let udai_debt = Uint128::new(3100).checked_mul_ceil(udai.price).unwrap();
+    // mars is counted in the debt because it has a price
+    let umars_debt = Uint128::new(200).checked_mul_ceil(umars.price).unwrap();
+    let expected_debt = udai_debt + umars_debt;
+    assert_eq!(res.total_debt_value, expected_debt);
 }
 
 #[test]

--- a/packages/health-computer/tests/tests/test_max_swap_validation.rs
+++ b/packages/health-computer/tests/tests/test_max_swap_validation.rs
@@ -107,10 +107,10 @@ fn missing_params() {
         vaults_data,
     };
 
-    let err: HealthError = h
+    let res = h
         .max_swap_amount_estimate(&umars.denom, &udai.denom, &SwapKind::Default, Decimal::zero())
-        .unwrap_err();
-    assert_eq!(err, HealthError::MissingParams(umars.denom));
+        .unwrap();
+    assert_eq!(res, Uint128::zero());
 }
 
 #[test]

--- a/packages/types/src/adapters/params.rs
+++ b/packages/types/src/adapters/params.rs
@@ -37,7 +37,7 @@ impl Params {
         &self,
         querier: &QuerierWrapper,
         denom: &str,
-    ) -> StdResult<AssetParams> {
+    ) -> StdResult<Option<AssetParams>> {
         querier.query_wasm_smart(
             self.address().to_string(),
             &QueryMsg::AssetParams {

--- a/packages/types/src/params/msg.rs
+++ b/packages/types/src/params/msg.rs
@@ -35,7 +35,7 @@ pub enum QueryMsg {
     #[returns(super::msg::ConfigResponse)]
     Config {},
 
-    #[returns(super::asset::AssetParams)]
+    #[returns(Option<super::asset::AssetParams>)]
     AssetParams {
         denom: String,
     },

--- a/schemas/mars-params/mars-params.json
+++ b/schemas/mars-params/mars-params.json
@@ -1411,49 +1411,59 @@
     },
     "asset_params": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "AssetParamsBase_for_Addr",
-      "type": "object",
-      "required": [
-        "credit_manager",
-        "denom",
-        "deposit_cap",
-        "liquidation_bonus",
-        "liquidation_threshold",
-        "max_loan_to_value",
-        "protocol_liquidation_fee",
-        "red_bank"
-      ],
-      "properties": {
-        "credit_manager": {
-          "$ref": "#/definitions/CmSettings_for_Addr"
+      "title": "Nullable_AssetParamsBase_for_Addr",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AssetParamsBase_for_Addr"
         },
-        "denom": {
-          "type": "string"
-        },
-        "deposit_cap": {
-          "$ref": "#/definitions/Uint128"
-        },
-        "liquidation_bonus": {
-          "$ref": "#/definitions/LiquidationBonus"
-        },
-        "liquidation_threshold": {
-          "$ref": "#/definitions/Decimal"
-        },
-        "max_loan_to_value": {
-          "$ref": "#/definitions/Decimal"
-        },
-        "protocol_liquidation_fee": {
-          "$ref": "#/definitions/Decimal"
-        },
-        "red_bank": {
-          "$ref": "#/definitions/RedBankSettings"
+        {
+          "type": "null"
         }
-      },
-      "additionalProperties": false,
+      ],
       "definitions": {
         "Addr": {
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
+        },
+        "AssetParamsBase_for_Addr": {
+          "type": "object",
+          "required": [
+            "credit_manager",
+            "denom",
+            "deposit_cap",
+            "liquidation_bonus",
+            "liquidation_threshold",
+            "max_loan_to_value",
+            "protocol_liquidation_fee",
+            "red_bank"
+          ],
+          "properties": {
+            "credit_manager": {
+              "$ref": "#/definitions/CmSettings_for_Addr"
+            },
+            "denom": {
+              "type": "string"
+            },
+            "deposit_cap": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "liquidation_bonus": {
+              "$ref": "#/definitions/LiquidationBonus"
+            },
+            "liquidation_threshold": {
+              "$ref": "#/definitions/Decimal"
+            },
+            "max_loan_to_value": {
+              "$ref": "#/definitions/Decimal"
+            },
+            "protocol_liquidation_fee": {
+              "$ref": "#/definitions/Decimal"
+            },
+            "red_bank": {
+              "$ref": "#/definitions/RedBankSettings"
+            }
+          },
+          "additionalProperties": false
         },
         "CmSettings_for_Addr": {
           "type": "object",

--- a/scripts/types/generated/mars-params/MarsParams.client.ts
+++ b/scripts/types/generated/mars-params/MarsParams.client.ts
@@ -39,6 +39,7 @@ import {
   ArrayOfVaultConfigBaseForAddr,
   VaultConfigBaseForAddr,
   PaginationResponseForVaultConfigBaseForAddr,
+  NullableAssetParamsBaseForAddr,
   ConfigResponse,
   OwnerResponse,
 } from './MarsParams.types'
@@ -46,7 +47,7 @@ export interface MarsParamsReadOnlyInterface {
   contractAddress: string
   owner: () => Promise<OwnerResponse>
   config: () => Promise<ConfigResponse>
-  assetParams: ({ denom }: { denom: string }) => Promise<AssetParamsBaseForAddr>
+  assetParams: ({ denom }: { denom: string }) => Promise<NullableAssetParamsBaseForAddr>
   allAssetParams: ({
     limit,
     startAfter,
@@ -108,7 +109,7 @@ export class MarsParamsQueryClient implements MarsParamsReadOnlyInterface {
       config: {},
     })
   }
-  assetParams = async ({ denom }: { denom: string }): Promise<AssetParamsBaseForAddr> => {
+  assetParams = async ({ denom }: { denom: string }): Promise<NullableAssetParamsBaseForAddr> => {
     return this.client.queryContractSmart(this.contractAddress, {
       asset_params: {
         denom,

--- a/scripts/types/generated/mars-params/MarsParams.react-query.ts
+++ b/scripts/types/generated/mars-params/MarsParams.react-query.ts
@@ -40,6 +40,7 @@ import {
   ArrayOfVaultConfigBaseForAddr,
   VaultConfigBaseForAddr,
   PaginationResponseForVaultConfigBaseForAddr,
+  NullableAssetParamsBaseForAddr,
   ConfigResponse,
   OwnerResponse,
 } from './MarsParams.types'
@@ -243,17 +244,17 @@ export function useMarsParamsAllAssetParamsQuery<TData = ArrayOfAssetParamsBaseF
   )
 }
 export interface MarsParamsAssetParamsQuery<TData>
-  extends MarsParamsReactQuery<AssetParamsBaseForAddr, TData> {
+  extends MarsParamsReactQuery<NullableAssetParamsBaseForAddr, TData> {
   args: {
     denom: string
   }
 }
-export function useMarsParamsAssetParamsQuery<TData = AssetParamsBaseForAddr>({
+export function useMarsParamsAssetParamsQuery<TData = NullableAssetParamsBaseForAddr>({
   client,
   args,
   options,
 }: MarsParamsAssetParamsQuery<TData>) {
-  return useQuery<AssetParamsBaseForAddr, Error, TData>(
+  return useQuery<NullableAssetParamsBaseForAddr, Error, TData>(
     marsParamsQueryKeys.assetParams(client?.contractAddress, args),
     () =>
       client

--- a/scripts/types/generated/mars-params/MarsParams.types.ts
+++ b/scripts/types/generated/mars-params/MarsParams.types.ts
@@ -237,6 +237,7 @@ export interface PaginationResponseForVaultConfigBaseForAddr {
   data: VaultConfigBaseForAddr[]
   metadata: Metadata
 }
+export type NullableAssetParamsBaseForAddr = AssetParamsBaseForAddr | null
 export interface ConfigResponse {
   address_provider: string
 }


### PR DESCRIPTION
We don't support not whitelisted coins. Currently we use whitelisting in Credit Manager contract for:
- deposit
- borrow
- lend
- swap
- zap
- enter vault

This PR removes whitelisting for deposit and swap to be able to trade any asset. Moreover, not whitelisted assets don't count towards Health Factor.