### PR TITLE
MP-2381. Fund manager acc

### DIFF
--- a/contracts/credit-manager/src/execute.rs
+++ b/contracts/credit-manager/src/execute.rs
@@ -352,15 +352,15 @@ fn validate_account(
     deps: &DepsMut,
     info: &MessageInfo,
     acc_id: &String,
-    actions: &Vec<Action>,
+    actions: &[Action],
 ) -> Result<(), ContractError> {
     let kind = get_account_kind(deps.storage, acc_id)?;
-    Ok(match kind {
+    match kind {
         // Fund manager wallet can interact with the account managing the vault funds.
         // This wallet can't deposit/withdraw from the account directly.
         AccountKind::FundManager {
             vault_addr,
-        } if info.sender.to_string() != vault_addr => {
+        } if info.sender != vault_addr => {
             assert_is_token_owner(deps, &info.sender, acc_id)?;
 
             let actions_not_allowed = actions.iter().any(|action| {
@@ -384,7 +384,9 @@ fn validate_account(
         AccountKind::Default | AccountKind::HighLeveredStrategy => {
             assert_is_token_owner(deps, &info.sender, acc_id)?
         }
-    })
+    }
+
+    Ok(())
 }
 
 pub fn execute_callback(

--- a/contracts/credit-manager/src/execute.rs
+++ b/contracts/credit-manager/src/execute.rs
@@ -50,6 +50,13 @@ pub fn create_credit_account(
         account_nft.query_next_id(&deps.querier)?
     };
 
+    if let AccountKind::FundManager {
+        vault_addr,
+    } = &kind
+    {
+        deps.api.addr_validate(vault_addr)?;
+    }
+
     ACCOUNT_KINDS.save(deps.storage, &next_id, &kind)?;
 
     let nft_mint_msg = CosmosMsg::Wasm(WasmMsg::Execute {

--- a/contracts/credit-manager/tests/tests/mod.rs
+++ b/contracts/credit-manager/tests/tests/mod.rs
@@ -12,6 +12,7 @@ mod test_enumerate_coin_balances;
 mod test_enumerate_debt_shares;
 mod test_enumerate_total_debt_shares;
 mod test_enumerate_vault_positions;
+mod test_fund_manager_accounts;
 mod test_health;
 mod test_hls_accounts;
 mod test_instantiate;

--- a/contracts/credit-manager/tests/tests/test_fund_manager_accounts.rs
+++ b/contracts/credit-manager/tests/tests/test_fund_manager_accounts.rs
@@ -1,0 +1,126 @@
+use cosmwasm_std::{coins, Addr, Coin, Uint128};
+use mars_credit_manager::error::ContractError;
+use mars_types::{
+    credit_manager::{Action, ActionAmount, ActionCoin},
+    health::AccountKind,
+};
+
+use super::helpers::{assert_err, uosmo_info, AccountToFund, MockEnv};
+
+#[test]
+fn fund_manager_wallet_cannot_deposit_and_withdraw() {
+    let coin_info = uosmo_info();
+
+    let fund_manager_wallet = Addr::unchecked("fund_manager_wallet");
+    let fund_manager_vault = Addr::unchecked("fund_manager_vault");
+    let mut mock = MockEnv::new()
+        .set_params(&[coin_info.clone()])
+        .fund_account(AccountToFund {
+            addr: fund_manager_wallet.clone(),
+            funds: coins(300, coin_info.denom.clone()),
+        })
+        .build()
+        .unwrap();
+    let account_id = mock
+        .create_credit_account_v2(
+            &fund_manager_wallet,
+            AccountKind::FundManager {
+                vault_addr: fund_manager_vault.to_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    // deposit not allowed
+    let deposit_amount = Uint128::new(234);
+    let res = mock.update_credit_account(
+        &account_id,
+        &fund_manager_wallet,
+        vec![Action::Deposit(coin_info.to_coin(deposit_amount.u128()))],
+        &[Coin::new(deposit_amount.into(), coin_info.denom.clone())],
+    );
+    assert_err(
+        res,
+        ContractError::Unauthorized {
+            user: account_id.to_string(),
+            action: "deposit, withdraw, refund_all_coin_balances".to_string(),
+        },
+    );
+
+    // withdraw not allowed
+    let res = mock.update_credit_account(
+        &account_id,
+        &fund_manager_wallet,
+        vec![Action::Withdraw(ActionCoin {
+            denom: coin_info.denom.clone(),
+            amount: ActionAmount::AccountBalance,
+        })],
+        &[],
+    );
+    assert_err(
+        res,
+        ContractError::Unauthorized {
+            user: account_id.to_string(),
+            action: "deposit, withdraw, refund_all_coin_balances".to_string(),
+        },
+    );
+
+    // refund_all_coin_balances not allowed
+    let res = mock.update_credit_account(
+        &account_id,
+        &fund_manager_wallet,
+        vec![Action::RefundAllCoinBalances {}],
+        &[],
+    );
+    assert_err(
+        res,
+        ContractError::Unauthorized {
+            user: account_id.to_string(),
+            action: "deposit, withdraw, refund_all_coin_balances".to_string(),
+        },
+    );
+
+    // combination of above msgs not allowed
+    let res = mock.update_credit_account(
+        &account_id,
+        &fund_manager_wallet,
+        vec![
+            Action::Deposit(coin_info.to_coin(deposit_amount.u128())),
+            Action::Withdraw(ActionCoin {
+                denom: coin_info.denom.clone(),
+                amount: ActionAmount::AccountBalance,
+            }),
+            Action::RefundAllCoinBalances {},
+        ],
+        &[Coin::new(deposit_amount.into(), coin_info.denom.clone())],
+    );
+    assert_err(
+        res,
+        ContractError::Unauthorized {
+            user: account_id.to_string(),
+            action: "deposit, withdraw, refund_all_coin_balances".to_string(),
+        },
+    );
+
+    // not allowed action composed with allowed action
+    let deposit_amount = Uint128::new(234);
+    let res = mock.update_credit_account(
+        &account_id,
+        &fund_manager_wallet,
+        vec![
+            Action::Deposit(coin_info.to_coin(deposit_amount.u128())),
+            Action::Lend(ActionCoin {
+                denom: coin_info.denom.clone(),
+                amount: ActionAmount::AccountBalance,
+            }),
+        ],
+        &[Coin::new(deposit_amount.into(), coin_info.denom.clone())],
+    );
+    assert_err(
+        res,
+        ContractError::Unauthorized {
+            user: account_id.to_string(),
+            action: "deposit, withdraw, refund_all_coin_balances".to_string(),
+        },
+    );
+}

--- a/contracts/credit-manager/tests/tests/test_fund_manager_accounts.rs
+++ b/contracts/credit-manager/tests/tests/test_fund_manager_accounts.rs
@@ -124,3 +124,107 @@ fn fund_manager_wallet_cannot_deposit_and_withdraw() {
         },
     );
 }
+
+#[test]
+fn fund_manager_wallet_can_work_on_behalf_of_vault() {
+    let coin_info = uosmo_info();
+
+    let fund_manager_wallet = Addr::unchecked("fund_manager_wallet");
+    let fund_manager_vault = Addr::unchecked("fund_manager_vault");
+    let funded_amt = Uint128::new(10000);
+    let mut mock = MockEnv::new()
+        .set_params(&[coin_info.clone()])
+        .fund_account(AccountToFund {
+            addr: fund_manager_wallet.clone(),
+            funds: coins(funded_amt.u128(), coin_info.denom.clone()),
+        })
+        .fund_account(AccountToFund {
+            addr: fund_manager_vault.clone(),
+            funds: coins(funded_amt.u128(), coin_info.denom.clone()),
+        })
+        .build()
+        .unwrap();
+    let account_id = mock
+        .create_credit_account_v2(
+            &fund_manager_wallet,
+            AccountKind::FundManager {
+                vault_addr: fund_manager_vault.to_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    // deposit from vault to fund manager account
+    let deposit_amount = Uint128::new(234);
+    mock.update_credit_account(
+        &account_id,
+        &fund_manager_vault,
+        vec![Action::Deposit(coin_info.to_coin(deposit_amount.u128()))],
+        &[Coin::new(deposit_amount.into(), coin_info.denom.clone())],
+    )
+    .unwrap();
+
+    let res = mock.query_positions(&account_id);
+    let assets_res = res.deposits.first().unwrap();
+    assert_eq!(res.deposits.len(), 1);
+    assert_eq!(assets_res.amount, deposit_amount);
+    assert_eq!(assets_res.denom, coin_info.denom);
+
+    let coin = mock.query_balance(&fund_manager_wallet, &coin_info.denom);
+    assert_eq!(coin.amount, funded_amt);
+    let coin = mock.query_balance(&fund_manager_vault, &coin_info.denom);
+    assert_eq!(coin.amount, funded_amt - deposit_amount);
+    let coin = mock.query_balance(&mock.rover, &coin_info.denom);
+    assert_eq!(coin.amount, deposit_amount);
+
+    // execute lend from fund manager wallet
+    mock.update_credit_account(
+        &account_id,
+        &fund_manager_wallet,
+        vec![Action::Lend(ActionCoin {
+            denom: coin_info.denom.clone(),
+            amount: ActionAmount::AccountBalance,
+        })],
+        &[],
+    )
+    .unwrap();
+
+    let res = mock.query_positions(&account_id);
+    let lent_res = res.lends.first().unwrap();
+    assert_eq!(res.lends.len(), 1);
+    assert_eq!(lent_res.denom, coin_info.denom);
+    let lent_amount = deposit_amount + Uint128::one(); // simulated yield
+    assert_eq!(lent_res.amount, lent_amount);
+
+    let coin = mock.query_balance(&mock.rover, &coin_info.denom);
+    assert_eq!(coin.amount, Uint128::zero());
+
+    // vault unlend and withdraw
+    mock.update_credit_account(
+        &account_id,
+        &fund_manager_vault,
+        vec![
+            Action::Reclaim(ActionCoin {
+                denom: coin_info.denom.clone(),
+                amount: ActionAmount::AccountBalance,
+            }),
+            Action::Withdraw(ActionCoin {
+                denom: coin_info.denom.clone(),
+                amount: ActionAmount::AccountBalance,
+            }),
+        ],
+        &[],
+    )
+    .unwrap();
+
+    let res = mock.query_positions(&account_id);
+    assert!(res.deposits.is_empty());
+    assert!(res.lends.is_empty());
+
+    let coin = mock.query_balance(&fund_manager_wallet, &coin_info.denom);
+    assert_eq!(coin.amount, funded_amt);
+    let coin = mock.query_balance(&fund_manager_vault, &coin_info.denom);
+    assert_eq!(coin.amount, funded_amt + Uint128::one()); // simulated yield
+    let coin = mock.query_balance(&mock.rover, &coin_info.denom);
+    assert_eq!(coin.amount, Uint128::zero());
+}

--- a/packages/health-computer/src/health_computer.rs
+++ b/packages/health-computer/src/health_computer.rs
@@ -107,6 +107,9 @@ impl HealthComputer {
 
         let withdraw_denom_max_ltv = match self.kind {
             AccountKind::Default => params.max_loan_to_value,
+            AccountKind::FundManager {
+                ..
+            } => params.max_loan_to_value,
             AccountKind::HighLeveredStrategy => {
                 params
                     .credit_manager
@@ -278,6 +281,9 @@ impl HealthComputer {
 
         let borrow_denom_max_ltv = match self.kind {
             AccountKind::Default => params.max_loan_to_value,
+            AccountKind::FundManager {
+                ..
+            } => params.max_loan_to_value,
             AccountKind::HighLeveredStrategy => {
                 params
                     .credit_manager
@@ -348,6 +354,9 @@ impl HealthComputer {
                 let checked_vault_max_ltv = if *whitelisted {
                     match self.kind {
                         AccountKind::Default => *max_loan_to_value,
+                        AccountKind::FundManager {
+                            ..
+                        } => *max_loan_to_value,
                         AccountKind::HighLeveredStrategy => {
                             hls.as_ref()
                                 .ok_or(MissingHLSParams(addr.to_string()))?
@@ -535,6 +544,9 @@ impl HealthComputer {
 
             let checked_liquidation_threshold = match self.kind {
                 AccountKind::Default => *liquidation_threshold,
+                AccountKind::FundManager {
+                    ..
+                } => *liquidation_threshold,
                 AccountKind::HighLeveredStrategy => {
                     hls.as_ref().ok_or(MissingHLSParams(c.denom.clone()))?.liquidation_threshold
                 }
@@ -588,6 +600,9 @@ impl HealthComputer {
             let checked_vault_max_ltv = if *whitelisted && base_params.credit_manager.whitelisted {
                 match self.kind {
                     AccountKind::Default => *max_loan_to_value,
+                    AccountKind::FundManager {
+                        ..
+                    } => *max_loan_to_value,
                     AccountKind::HighLeveredStrategy => {
                         hls.as_ref().ok_or(MissingHLSParams(addr.to_string()))?.max_loan_to_value
                     }
@@ -604,6 +619,9 @@ impl HealthComputer {
 
             let checked_liquidation_threshold = match self.kind {
                 AccountKind::Default => *liquidation_threshold,
+                AccountKind::FundManager {
+                    ..
+                } => *liquidation_threshold,
                 AccountKind::HighLeveredStrategy => {
                     hls.as_ref().ok_or(MissingHLSParams(addr.to_string()))?.liquidation_threshold
                 }
@@ -646,6 +664,9 @@ impl HealthComputer {
 
         match self.kind {
             AccountKind::Default => Ok(params.max_loan_to_value),
+            AccountKind::FundManager {
+                ..
+            } => Ok(params.max_loan_to_value),
             AccountKind::HighLeveredStrategy => Ok(params
                 .credit_manager
                 .hls

--- a/packages/health-computer/tests/tests/helpers/prop_test_strategies.rs
+++ b/packages/health-computer/tests/tests/helpers/prop_test_strategies.rs
@@ -18,7 +18,13 @@ use proptest::{
 };
 
 fn random_account_kind() -> impl Strategy<Value = AccountKind> {
-    prop_oneof![Just(AccountKind::Default), Just(AccountKind::HighLeveredStrategy)]
+    prop_oneof![
+        Just(AccountKind::Default),
+        Just(AccountKind::HighLeveredStrategy),
+        Just(AccountKind::FundManager {
+            vault_addr: "vault_addr".to_string()
+        })
+    ]
 }
 
 fn random_denom() -> impl Strategy<Value = String> {

--- a/packages/types/src/health/account.rs
+++ b/packages/types/src/health/account.rs
@@ -9,6 +9,13 @@ use tsify::Tsify;
 pub enum AccountKind {
     Default,
     HighLeveredStrategy,
+
+    /// A vault that is managed by a fund manager.
+    /// Fund manager (wallet) is responsible for managing the vault.
+    /// Fund manager can't deposit and withdraw funds from the vault.
+    FundManager {
+        vault_addr: String,
+    },
 }
 
 impl fmt::Display for AccountKind {

--- a/schemas/mars-credit-manager/mars-credit-manager.json
+++ b/schemas/mars-credit-manager/mars-credit-manager.json
@@ -324,10 +324,36 @@
     ],
     "definitions": {
       "AccountKind": {
-        "type": "string",
-        "enum": [
-          "default",
-          "high_levered_strategy"
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "default",
+              "high_levered_strategy"
+            ]
+          },
+          {
+            "description": "A vault that is managed by a fund manager. Fund manager (wallet) is responsible for managing the vault. Fund manager can't deposit and withdraw funds from the vault.",
+            "type": "object",
+            "required": [
+              "fund_manager"
+            ],
+            "properties": {
+              "fund_manager": {
+                "type": "object",
+                "required": [
+                  "vault_addr"
+                ],
+                "properties": {
+                  "vault_addr": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       },
       "AccountNftBase_for_String": {
@@ -2645,10 +2671,36 @@
     "account_kind": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "AccountKind",
-      "type": "string",
-      "enum": [
-        "default",
-        "high_levered_strategy"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "default",
+            "high_levered_strategy"
+          ]
+        },
+        {
+          "description": "A vault that is managed by a fund manager. Fund manager (wallet) is responsible for managing the vault. Fund manager can't deposit and withdraw funds from the vault.",
+          "type": "object",
+          "required": [
+            "fund_manager"
+          ],
+          "properties": {
+            "fund_manager": {
+              "type": "object",
+              "required": [
+                "vault_addr"
+              ],
+              "properties": {
+                "vault_addr": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "accounts": {
@@ -2676,10 +2728,36 @@
           "additionalProperties": false
         },
         "AccountKind": {
-          "type": "string",
-          "enum": [
-            "default",
-            "high_levered_strategy"
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "default",
+                "high_levered_strategy"
+              ]
+            },
+            {
+              "description": "A vault that is managed by a fund manager. Fund manager (wallet) is responsible for managing the vault. Fund manager can't deposit and withdraw funds from the vault.",
+              "type": "object",
+              "required": [
+                "fund_manager"
+              ],
+              "properties": {
+                "fund_manager": {
+                  "type": "object",
+                  "required": [
+                    "vault_addr"
+                  ],
+                  "properties": {
+                    "vault_addr": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         }
       }
@@ -3227,10 +3305,36 @@
       "additionalProperties": false,
       "definitions": {
         "AccountKind": {
-          "type": "string",
-          "enum": [
-            "default",
-            "high_levered_strategy"
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "default",
+                "high_levered_strategy"
+              ]
+            },
+            {
+              "description": "A vault that is managed by a fund manager. Fund manager (wallet) is responsible for managing the vault. Fund manager can't deposit and withdraw funds from the vault.",
+              "type": "object",
+              "required": [
+                "fund_manager"
+              ],
+              "properties": {
+                "fund_manager": {
+                  "type": "object",
+                  "required": [
+                    "vault_addr"
+                  ],
+                  "properties": {
+                    "vault_addr": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         },
         "Addr": {

--- a/schemas/mars-rover-health-computer/mars-rover-health-computer.json
+++ b/schemas/mars-rover-health-computer/mars-rover-health-computer.json
@@ -26,10 +26,36 @@
   "additionalProperties": false,
   "definitions": {
     "AccountKind": {
-      "type": "string",
-      "enum": [
-        "default",
-        "high_levered_strategy"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "default",
+            "high_levered_strategy"
+          ]
+        },
+        {
+          "description": "A vault that is managed by a fund manager. Fund manager (wallet) is responsible for managing the vault. Fund manager can't deposit and withdraw funds from the vault.",
+          "type": "object",
+          "required": [
+            "fund_manager"
+          ],
+          "properties": {
+            "fund_manager": {
+              "type": "object",
+              "required": [
+                "vault_addr"
+              ],
+              "properties": {
+                "vault_addr": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "Addr": {

--- a/schemas/mars-rover-health/mars-rover-health.json
+++ b/schemas/mars-rover-health/mars-rover-health.json
@@ -223,10 +223,36 @@
     ],
     "definitions": {
       "AccountKind": {
-        "type": "string",
-        "enum": [
-          "default",
-          "high_levered_strategy"
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "default",
+              "high_levered_strategy"
+            ]
+          },
+          {
+            "description": "A vault that is managed by a fund manager. Fund manager (wallet) is responsible for managing the vault. Fund manager can't deposit and withdraw funds from the vault.",
+            "type": "object",
+            "required": [
+              "fund_manager"
+            ],
+            "properties": {
+              "fund_manager": {
+                "type": "object",
+                "required": [
+                  "vault_addr"
+                ],
+                "properties": {
+                  "vault_addr": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       },
       "ActionKind": {

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.client.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.client.ts
@@ -323,6 +323,7 @@ export interface MarsCreditManagerInterface extends MarsCreditManagerReadOnlyInt
   contractAddress: string
   sender: string
   createCreditAccount: (
+    accountKind: AccountKind,
     fee?: number | StdFee | 'auto',
     memo?: string,
     _funds?: Coin[],
@@ -422,6 +423,7 @@ export class MarsCreditManagerClient
   }
 
   createCreditAccount = async (
+    accountKind: AccountKind,
     fee: number | StdFee | 'auto' = 'auto',
     memo?: string,
     _funds?: Coin[],
@@ -430,7 +432,7 @@ export class MarsCreditManagerClient
       this.sender,
       this.contractAddress,
       {
-        create_credit_account: {},
+        create_credit_account: accountKind,
       },
       fee,
       memo,

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.react-query.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.react-query.ts
@@ -656,6 +656,7 @@ export function useMarsCreditManagerCreateCreditAccountV2Mutation(
 }
 export interface MarsCreditManagerCreateCreditAccountMutation {
   client: MarsCreditManagerClient
+  msg: AccountKind
   args?: {
     fee?: number | StdFee | 'auto'
     memo?: string

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
@@ -65,7 +65,13 @@ export type ExecuteMsg =
   | {
       callback: CallbackMsg
     }
-export type AccountKind = 'default' | 'high_levered_strategy'
+export type AccountKind =
+  | ('default' | 'high_levered_strategy')
+  | {
+      fund_manager: {
+        vault_addr: string
+      }
+    }
 export type Action =
   | {
       deposit: Coin

--- a/scripts/types/generated/mars-rover-health-computer/MarsRoverHealthComputer.types.ts
+++ b/scripts/types/generated/mars-rover-health-computer/MarsRoverHealthComputer.types.ts
@@ -19,7 +19,13 @@ export type HlsAssetTypeForAddr =
 export type Addr = string
 export type Decimal = string
 export type Uint128 = string
-export type AccountKind = 'default' | 'high_levered_strategy'
+export type AccountKind =
+  | ('default' | 'high_levered_strategy')
+  | {
+      fund_manager: {
+        vault_addr: string
+      }
+    }
 export type VaultPositionAmount =
   | {
       unlocked: VaultAmount

--- a/scripts/types/generated/mars-rover-health/MarsRoverHealth.types.ts
+++ b/scripts/types/generated/mars-rover-health/MarsRoverHealth.types.ts
@@ -52,7 +52,13 @@ export type QueryMsg =
       config: {}
     }
 export type ActionKind = 'default' | 'liquidation'
-export type AccountKind = 'default' | 'high_levered_strategy'
+export type AccountKind =
+  | ('default' | 'high_levered_strategy')
+  | {
+      fund_manager: {
+        vault_addr: string
+      }
+    }
 export interface ConfigResponse {
   credit_manager?: string | null
   owner_response: OwnerResponse


### PR DESCRIPTION
FundManager account has two actors - wallet which is the owner of the account (can’t deposit and withdraw from the account) and vault which can do whatever he wants on the account.

I changed the managed vault initialization logic. In the hackathon version, the credit manager had to transfer initializations to the contract vault, which created a tight connection between contracts. See here:
<img width="782" alt="Zrzut ekranu 2024-05-15 o 11 04 42" src="https://github.com/mars-protocol/contracts/assets/2192395/2498332e-d37c-481f-8f3b-66daa1b73547">
I am in favor of the Credit Manager knowing as little as possible about who uses it. Fund Manager will initialize the vault contract and in Credit Manager we will only link the account to the vault address and grant appropriate permissions for the Wallet and Fund Manager Vault. Basically we need:
- 1 msg to instantiate a vault
- 1 msg to mint a credit account and bind the account with Vault addr

Additionally, the Fund Manager can decide whether the Vault should be immutable or not.