### PR TITLE
Improve vault unlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
+ "cw-paginate",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw-vault-standard 0.4.0",

--- a/contracts/vault/Cargo.toml
+++ b/contracts/vault/Cargo.toml
@@ -25,6 +25,7 @@ cosmwasm-std      = { workspace = true, features = ["cosmwasm_1_1"] }
 cw2               = { workspace = true }
 cw-storage-plus   = { workspace = true }
 cw-utils          = { workspace = true }
+cw-paginate       = { workspace = true }
 cw-vault-standard = { workspace = true }
 mars-owner        = { workspace = true }
 mars-types        = { workspace = true }

--- a/contracts/vault/src/contract.rs
+++ b/contracts/vault/src/contract.rs
@@ -12,7 +12,8 @@ use crate::{
     instantiate::init,
     msg::{ExecuteMsg, ExtensionExecuteMsg, ExtensionQueryMsg, InstantiateMsg, QueryMsg},
     query::{
-        convert_to_base_tokens, convert_to_vault_tokens, query_user_unlocks, query_vault_info,
+        convert_to_base_tokens, convert_to_vault_tokens, query_all_unlocks, query_user_unlocks,
+        query_vault_info,
     },
     state::{BASE_TOKEN, PERFORMANCE_FEE_STATE, VAULT_TOKEN},
 };
@@ -100,6 +101,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
                 let user_addr = deps.api.addr_validate(&user_address)?;
                 to_json_binary(&query_user_unlocks(deps, user_addr)?)
             }
+            ExtensionQueryMsg::AllUnlocks {
+                start_after,
+                limit,
+            } => to_json_binary(&query_all_unlocks(deps, start_after, limit)?),
             ExtensionQueryMsg::PerformanceFeeState {} => {
                 to_json_binary(&PERFORMANCE_FEE_STATE.load(deps.storage)?)
             }

--- a/contracts/vault/src/execute.rs
+++ b/contracts/vault/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     attr, ensure_eq, to_json_binary, Coin, CosmosMsg, Deps, DepsMut, Env, Event, MessageInfo,
-    Response, StdError, Uint128, WasmMsg,
+    Order, Response, StdResult, Uint128, WasmMsg,
 };
 use mars_types::{
     credit_manager::{self, Action, ActionAmount, ActionCoin, Positions, QueryMsg},
@@ -142,17 +142,15 @@ pub fn unlock(
     let current_time = env.block.time.seconds();
     let cooldown_period = COOLDOWN_PERIOD.load(deps.storage)?;
     let cooldown_end = current_time + cooldown_period;
-    UNLOCKS.update(deps.storage, info.sender.to_string(), |maybe_unlocks| {
-        let mut unlocks = maybe_unlocks.unwrap_or_default();
-
-        unlocks.push(UnlockState {
+    UNLOCKS.save(
+        deps.storage,
+        (info.sender.as_str(), current_time),
+        &UnlockState {
             created_at: current_time,
             cooldown_end,
             vault_tokens: amount,
-        });
-
-        Ok::<Vec<UnlockState>, StdError>(unlocks)
-    })?;
+        },
+    )?;
 
     Ok(Response::new()
         .add_attribute("action", "unlock")
@@ -182,11 +180,18 @@ pub fn redeem(
     // check that only the expected base token was sent
     let vault_token_amount = cw_utils::must_pay(info, &vault_token.to_string())?;
 
-    let unlocks = UNLOCKS.may_load(deps.storage, recipient.to_string())?.unwrap_or_default();
+    let unlocks = UNLOCKS
+        .prefix(recipient.as_str())
+        .range(deps.storage, None, None, Order::Ascending)
+        .map(|item| {
+            let (_created_at, unlock) = item?;
+            Ok(unlock)
+        })
+        .collect::<StdResult<Vec<UnlockState>>>()?;
 
     // find all unlocked positions
     let current_time = env.block.time.seconds();
-    let (unlocked, unlocking): (Vec<_>, Vec<_>) =
+    let (unlocked, _unlocking): (Vec<_>, Vec<_>) =
         unlocks.into_iter().partition(|us| us.cooldown_end <= current_time);
 
     // cannot withdraw when there is zero unlocked positions
@@ -195,10 +200,8 @@ pub fn redeem(
     }
 
     // clear state if no more unlocking positions
-    if unlocking.is_empty() {
-        UNLOCKS.remove(deps.storage, recipient.to_string());
-    } else {
-        UNLOCKS.save(deps.storage, recipient.to_string(), &unlocking)?;
+    for unlock in &unlocked {
+        UNLOCKS.remove(deps.storage, (recipient.as_str(), unlock.created_at));
     }
 
     // compute the total vault tokens to be withdrawn

--- a/contracts/vault/src/execute.rs
+++ b/contracts/vault/src/execute.rs
@@ -199,7 +199,7 @@ pub fn redeem(
         return Err(ContractError::UnlockedPositionsNotFound {});
     }
 
-    // clear state if no more unlocking positions
+    // remove unlocked positions
     for unlock in &unlocked {
         UNLOCKS.remove(deps.storage, (recipient.as_str(), unlock.created_at));
     }

--- a/contracts/vault/src/msg.rs
+++ b/contracts/vault/src/msg.rs
@@ -64,6 +64,12 @@ pub enum ExtensionQueryMsg {
         user_address: String,
     },
 
+    AllUnlocks {
+        // (user address, created_at)
+        start_after: Option<(String, u64)>,
+        limit: Option<u32>,
+    },
+
     PerformanceFeeState {},
 }
 
@@ -106,6 +112,7 @@ pub struct UnlockState {
 #[cw_serde]
 #[derive(Default)]
 pub struct VaultUnlock {
+    pub user_address: String,
     pub created_at: u64,
     pub cooldown_end: u64,
     pub vault_tokens: Uint128,

--- a/contracts/vault/src/state.rs
+++ b/contracts/vault/src/state.rs
@@ -28,7 +28,7 @@ pub const SUBTITLE: Item<String> = Item::new("subtitle");
 pub const DESCRIPTION: Item<String> = Item::new("desc");
 
 pub const COOLDOWN_PERIOD: Item<u64> = Item::new("cooldown_period");
-pub const UNLOCKS: Map<String, Vec<UnlockState>> = Map::new("unlocks");
+pub const UNLOCKS: Map<(&str, u64), UnlockState> = Map::new("unlocks");
 
 pub const PERFORMANCE_FEE_CONFIG: Item<PerformanceFeeConfig> = Item::new("performance_fee_config");
 pub const PERFORMANCE_FEE_STATE: Item<PerformanceFeeState> = Item::new("performance_fee_state");

--- a/contracts/vault/tests/tests/vault_helpers.rs
+++ b/contracts/vault/tests/tests/vault_helpers.rs
@@ -1,6 +1,7 @@
 use anyhow::Result as AnyResult;
 use cosmwasm_std::{Addr, Coin, Uint128};
 use cw_multi_test::{AppResponse, Executor};
+use cw_paginate::PaginationResponse;
 use mars_vault::{
     msg::{
         ExecuteMsg, ExtensionExecuteMsg, ExtensionQueryMsg, QueryMsg, VaultInfoResponseExt,
@@ -125,6 +126,25 @@ pub fn query_user_unlocks(mock_env: &MockEnv, vault: &Addr, user_addr: &Addr) ->
             vault.to_string(),
             &QueryMsg::VaultExtension(ExtensionQueryMsg::UserUnlocks {
                 user_address: user_addr.to_string(),
+            }),
+        )
+        .unwrap()
+}
+
+pub fn query_all_unlocks(
+    mock_env: &MockEnv,
+    vault: &Addr,
+    start_after: Option<(String, u64)>,
+    limit: Option<u32>,
+) -> PaginationResponse<VaultUnlock> {
+    mock_env
+        .app
+        .wrap()
+        .query_wasm_smart(
+            vault.to_string(),
+            &QueryMsg::VaultExtension(ExtensionQueryMsg::AllUnlocks {
+                start_after,
+                limit,
             }),
         )
         .unwrap()

--- a/schemas/mars-vault/mars-vault.json
+++ b/schemas/mars-vault/mars-vault.json
@@ -518,6 +518,47 @@
           {
             "type": "object",
             "required": [
+              "all_unlocks"
+            ],
+            "properties": {
+              "all_unlocks": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "start_after": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
               "performance_fee_state"
             ],
             "properties": {

--- a/scripts/types/generated/mars-vault/MarsVault.types.ts
+++ b/scripts/types/generated/mars-vault/MarsVault.types.ts
@@ -99,6 +99,12 @@ export type ExtensionQueryMsg =
       }
     }
   | {
+      all_unlocks: {
+        limit?: number | null
+        start_after?: [string, number] | null
+      }
+    }
+  | {
       performance_fee_state: {}
     }
 export interface VaultInfoResponse {


### PR DESCRIPTION
Use `created_at` as part of the `unlocks` key so we can paginate in ASC/DESC order.