### PR TITLE
MP-2435. Keep claimed rewards in the account

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,5 @@
 [advisories]
 # Ignore the following advisory IDs.
 # Reported vulnerabilities relate to test-tube which is only used for testing.
-ignore = ["RUSTSEC-2024-0003", "RUSTSEC-2024-0006", "RUSTSEC-2024-0019", "RUSTSEC-2024-0332", "RUSTSEC-2024-0336"]
+# RUSTSEC-2024-0344 - no newer dependency fixing the issue in cosmwasm
+ignore = ["RUSTSEC-2024-0003", "RUSTSEC-2024-0006", "RUSTSEC-2024-0019", "RUSTSEC-2024-0332", "RUSTSEC-2024-0336", "RUSTSEC-2024-0344"]

--- a/audit.txt
+++ b/audit.txt
@@ -1,0 +1,1445 @@
+[cargo-make] INFO - cargo make 0.37.9
+[cargo-make] INFO - Calling cargo metadata to extract project info
+[cargo-make] INFO - Cargo metadata done
+[cargo-make] INFO - Build File: Makefile.toml
+[cargo-make] INFO - Task: audit
+[cargo-make] INFO - Profile: development
+[cargo-make] INFO - Running Task: legacy-migration
+[cargo-make] INFO - Execute Command: "rustup" "run" "1.75.0" "cargo" "audit"
+    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
+      Loaded 629 security advisories (from /Users/piobab/.cargo/advisory-db)
+    Updating crates.io index
+    Scanning Cargo.lock for vulnerabilities (446 crate dependencies)
+Crate:     curve25519-dalek
+Version:   3.2.0
+Title:     Timing variability in `curve25519-dalek`'s `Scalar29::sub`/`Scalar52::sub`
+Date:      2024-06-18
+ID:        RUSTSEC-2024-0344
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0344
+Solution:  Upgrade to >=4.1.3
+Dependency tree:
+curve25519-dalek 3.2.0
+└── ed25519-zebra 3.1.0
+    └── cosmwasm-crypto 1.5.5
+        └── cosmwasm-std 1.5.5
+            ├── test-tube 0.5.0
+            │   ├── osmosis-test-tube 22.1.0
+            │   │   ├── mars-zapper-osmosis 2.0.0
+            │   │   ├── mars-integration-tests 2.0.0
+            │   │   └── cw-it 0.3.0
+            │   │       ├── mars-zapper-astroport 2.0.0
+            │   │       ├── mars-testing 2.0.0
+            │   │       │   ├── mars-zapper-astroport 2.0.0
+            │   │       │   ├── mars-vault 2.0.0
+            │   │       │   │   ├── mars-testing 2.0.0
+            │   │       │   │   └── mars-credit-manager 2.0.3
+            │   │       │   │       └── mars-testing 2.0.0
+            │   │       │   ├── mars-swapper-osmosis 2.0.3
+            │   │       │   │   └── mars-integration-tests 2.0.0
+            │   │       │   ├── mars-swapper-astroport 2.0.0
+            │   │       │   │   └── mars-testing 2.0.0
+            │   │       │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   │       │   │   ├── mars-testing 2.0.0
+            │   │       │   │   └── mars-integration-tests 2.0.0
+            │   │       │   ├── mars-rewards-collector-neutron 2.0.0
+            │   │       │   ├── mars-red-bank 2.0.1
+            │   │       │   │   ├── mars-testing 2.0.0
+            │   │       │   │   ├── mars-integration-tests 2.0.0
+            │   │       │   │   └── mars-incentives 2.0.0
+            │   │       │   │       ├── mars-testing 2.0.0
+            │   │       │   │       └── mars-integration-tests 2.0.0
+            │   │       │   ├── mars-params 2.0.1
+            │   │       │   │   ├── mars-testing 2.0.0
+            │   │       │   │   ├── mars-rover-health 2.0.0
+            │   │       │   │   │   ├── mars-testing 2.0.0
+            │   │       │   │   │   └── mars-credit-manager 2.0.3
+            │   │       │   │   ├── mars-integration-tests 2.0.0
+            │   │       │   │   └── mars-credit-manager 2.0.3
+            │   │       │   ├── mars-oracle-wasm 2.0.0
+            │   │       │   │   ├── mars-zapper-astroport 2.0.0
+            │   │       │   │   ├── mars-testing 2.0.0
+            │   │       │   │   └── mars-swapper-astroport 2.0.0
+            │   │       │   ├── mars-oracle-osmosis 2.0.1
+            │   │       │   │   ├── mars-testing 2.0.0
+            │   │       │   │   └── mars-integration-tests 2.0.0
+            │   │       │   ├── mars-integration-tests 2.0.0
+            │   │       │   ├── mars-incentives 2.0.0
+            │   │       │   ├── mars-health 2.0.0
+            │   │       │   │   ├── mars-red-bank 2.0.1
+            │   │       │   │   └── mars-liquidation 1.0.0
+            │   │       │   │       ├── mars-red-bank 2.0.1
+            │   │       │   │       └── mars-credit-manager 2.0.3
+            │   │       │   ├── mars-credit-manager 2.0.3
+            │   │       │   └── mars-address-provider 2.0.0
+            │   │       │       ├── mars-testing 2.0.0
+            │   │       │       └── mars-credit-manager 2.0.3
+            │   │       ├── mars-swapper-osmosis 2.0.3
+            │   │       ├── mars-swapper-astroport 2.0.0
+            │   │       ├── mars-oracle-wasm 2.0.0
+            │   │       ├── mars-integration-tests 2.0.0
+            │   │       └── mars-incentives 2.0.0
+            │   └── cw-it 0.3.0
+            ├── pyth-sdk-cw 1.2.0
+            │   ├── mars-testing 2.0.0
+            │   ├── mars-oracle-wasm 2.0.0
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-oracle-base 2.0.0
+            │   │   ├── mars-oracle-wasm 2.0.0
+            │   │   ├── mars-oracle-osmosis 2.0.1
+            │   │   └── mars-integration-tests 2.0.0
+            │   └── mars-mock-pyth 2.0.0
+            │       └── mars-testing 2.0.0
+            ├── osmosis-test-tube 22.1.0
+            ├── osmosis-std 0.22.0
+            │   ├── test-tube 0.5.0
+            │   ├── osmosis-test-tube 22.1.0
+            │   ├── mars-zapper-osmosis 2.0.0
+            │   ├── mars-vault 2.0.0
+            │   ├── mars-testing 2.0.0
+            │   ├── mars-swapper-osmosis 2.0.3
+            │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   ├── mars-osmosis 2.0.0
+            │   │   ├── mars-swapper-osmosis 2.0.3
+            │   │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   │   ├── mars-oracle-osmosis 2.0.1
+            │   │   └── mars-integration-tests 2.0.0
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-integration-tests 2.0.0
+            │   ├── mars-incentives 2.0.0
+            │   ├── cw-it 0.3.0
+            │   └── apollo-cw-multi-test 0.18.0
+            │       └── cw-it 0.3.0
+            ├── osmosis-std 0.16.2
+            │   └── cw-dex 0.3.1
+            │       ├── mars-zapper-osmosis 2.0.0
+            │       ├── mars-zapper-base 2.0.0
+            │       │   ├── mars-zapper-osmosis 2.0.0
+            │       │   └── mars-zapper-astroport 2.0.0
+            │       └── mars-zapper-astroport 2.0.0
+            ├── neutron-sdk 0.10.0
+            │   └── mars-rewards-collector-neutron 2.0.0
+            ├── mars-zapper-osmosis 2.0.0
+            ├── mars-zapper-mock 2.0.0
+            │   ├── mars-testing 2.0.0
+            │   └── mars-credit-manager 2.0.3
+            ├── mars-zapper-base 2.0.0
+            ├── mars-zapper-astroport 2.0.0
+            ├── mars-vault 2.0.0
+            ├── mars-utils 2.0.0
+            │   ├── mars-types 2.0.0
+            │   │   ├── mars-zapper-osmosis 2.0.0
+            │   │   ├── mars-zapper-mock 2.0.0
+            │   │   ├── mars-zapper-base 2.0.0
+            │   │   ├── mars-zapper-astroport 2.0.0
+            │   │   ├── mars-vault 2.0.0
+            │   │   ├── mars-testing 2.0.0
+            │   │   ├── mars-swapper-osmosis 2.0.3
+            │   │   ├── mars-swapper-mock 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── mars-swapper-base 2.0.0
+            │   │   │   ├── mars-swapper-osmosis 2.0.3
+            │   │   │   └── mars-swapper-astroport 2.0.0
+            │   │   ├── mars-swapper-astroport 2.0.0
+            │   │   ├── mars-rover-health-computer 2.0.0
+            │   │   │   └── mars-rover-health 2.0.0
+            │   │   ├── mars-rover-health 2.0.0
+            │   │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   │   ├── mars-rewards-collector-neutron 2.0.0
+            │   │   ├── mars-rewards-collector-base 2.0.0
+            │   │   │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   │   │   └── mars-rewards-collector-neutron 2.0.0
+            │   │   ├── mars-red-bank 2.0.1
+            │   │   ├── mars-params 2.0.1
+            │   │   ├── mars-oracle-wasm 2.0.0
+            │   │   ├── mars-oracle-osmosis 2.0.1
+            │   │   ├── mars-oracle-base 2.0.0
+            │   │   ├── mars-mock-vault 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   ├── mars-rover-health 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── mars-mock-rover-health 2.0.0
+            │   │   │   └── mars-account-nft 2.0.0
+            │   │   │       ├── mars-testing 2.0.0
+            │   │   │       └── mars-credit-manager 2.0.3
+            │   │   ├── mars-mock-red-bank 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── mars-mock-oracle 2.0.0
+            │   │   │   ├── mars-vault 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   ├── mars-rover-health 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── mars-mock-incentives 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── mars-mock-credit-manager 2.0.0
+            │   │   │   ├── mars-rover-health 2.0.0
+            │   │   │   └── mars-account-nft 2.0.0
+            │   │   ├── mars-mock-astroport-incentives 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── mars-liquidation 1.0.0
+            │   │   ├── mars-interest-rate 2.0.0
+            │   │   │   ├── mars-red-bank 2.0.1
+            │   │   │   └── mars-params 2.0.1
+            │   │   ├── mars-integration-tests 2.0.0
+            │   │   ├── mars-incentives 2.0.0
+            │   │   ├── mars-health 2.0.0
+            │   │   ├── mars-credit-manager 2.0.3
+            │   │   ├── mars-address-provider 2.0.0
+            │   │   └── mars-account-nft 2.0.0
+            │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   ├── mars-rewards-collector-base 2.0.0
+            │   ├── mars-red-bank 2.0.1
+            │   ├── mars-params 2.0.1
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-oracle-base 2.0.0
+            │   ├── mars-integration-tests 2.0.0
+            │   ├── mars-incentives 2.0.0
+            │   └── mars-credit-manager 2.0.3
+            ├── mars-utils 1.0.0
+            ├── mars-utils 1.0.0
+            │   └── mars-red-bank-types 1.0.0
+            │       └── mars-rover 1.0.0
+            │           └── mars-account-nft 2.0.0
+            ├── mars-types 2.0.0
+            ├── mars-testing 2.0.0
+            ├── mars-swapper-osmosis 2.0.3
+            ├── mars-swapper-mock 2.0.0
+            ├── mars-swapper-base 2.0.0
+            ├── mars-swapper-astroport 2.0.0
+            ├── mars-rover-health-computer 2.0.0
+            ├── mars-rover-health 2.0.0
+            ├── mars-rover 1.0.0
+            ├── mars-rewards-collector-osmosis 2.0.1
+            ├── mars-rewards-collector-neutron 2.0.0
+            ├── mars-rewards-collector-base 2.0.0
+            ├── mars-red-bank-types 1.0.0
+            ├── mars-red-bank-types 1.0.0
+            ├── mars-red-bank 2.0.1
+            ├── mars-params 2.0.1
+            ├── mars-owner 2.0.0
+            │   ├── mars-vault 2.0.0
+            │   ├── mars-types 2.0.0
+            │   ├── mars-testing 2.0.0
+            │   ├── mars-swapper-osmosis 2.0.3
+            │   ├── mars-swapper-base 2.0.0
+            │   ├── mars-rover-health 2.0.0
+            │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   ├── mars-rewards-collector-base 2.0.0
+            │   ├── mars-red-bank 2.0.1
+            │   ├── mars-params 2.0.1
+            │   ├── mars-oracle-wasm 2.0.0
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-oracle-base 2.0.0
+            │   ├── mars-incentives 2.0.0
+            │   ├── mars-credit-manager 2.0.3
+            │   ├── mars-address-provider 2.0.0
+            │   └── mars-account-nft 2.0.0
+            ├── mars-owner 1.2.0
+            │   ├── mars-rover 1.0.0
+            │   ├── mars-red-bank-types 1.0.0
+            │   └── mars-red-bank-types 1.0.0
+            ├── mars-osmosis 2.0.0
+            ├── mars-oracle-wasm 2.0.0
+            ├── mars-oracle-osmosis 2.0.1
+            ├── mars-oracle-base 2.0.0
+            ├── mars-mock-vault 2.0.0
+            ├── mars-mock-rover-health 2.0.0
+            ├── mars-mock-red-bank 2.0.0
+            ├── mars-mock-pyth 2.0.0
+            ├── mars-mock-oracle 2.0.0
+            ├── mars-mock-incentives 2.0.0
+            ├── mars-mock-credit-manager 2.0.0
+            ├── mars-mock-astroport-incentives 2.0.0
+            ├── mars-liquidation 1.0.0
+            ├── mars-interest-rate 2.0.0
+            ├── mars-integration-tests 2.0.0
+            ├── mars-incentives 2.0.0
+            ├── mars-health 2.0.0
+            ├── mars-health 1.0.0
+            │   └── mars-rover 1.0.0
+            ├── mars-credit-manager 2.0.3
+            ├── mars-address-provider 2.0.0
+            ├── mars-account-nft 2.0.0
+            ├── ica-oracle 1.0.0
+            │   ├── mars-testing 2.0.0
+            │   ├── mars-oracle-wasm 2.0.0
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-oracle-base 2.0.0
+            │   └── mars-integration-tests 2.0.0
+            ├── cw721-base 0.18.0
+            │   ├── mars-types 2.0.0
+            │   ├── mars-testing 2.0.0
+            │   ├── mars-credit-manager 2.0.3
+            │   └── mars-account-nft 2.0.0
+            ├── cw721-base 0.16.0
+            │   ├── mars-rover 1.0.0
+            │   ├── mars-account-nft 2.0.0
+            │   └── cw721-base 0.18.0
+            ├── cw721 0.18.0
+            │   ├── mars-types 2.0.0
+            │   ├── mars-testing 2.0.0
+            │   ├── mars-credit-manager 2.0.3
+            │   ├── mars-account-nft 2.0.0
+            │   └── cw721-base 0.18.0
+            ├── cw721 0.16.0
+            │   ├── mars-rover 1.0.0
+            │   └── cw721-base 0.16.0
+            ├── cw3 1.1.1
+            │   └── astroport 3.11.1
+            │       ├── cw-it 0.3.0
+            │       └── astroport-incentives 1.0.0
+            │           └── cw-it 0.3.0
+            ├── cw20-base 0.15.1
+            │   ├── astroport-token 1.1.1
+            │   │   └── cw-it 0.3.0
+            │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+            │       └── cw-it 0.3.0
+            ├── cw20 1.1.2
+            │   ├── cw3 1.1.1
+            │   ├── cw-dex 0.3.1
+            │   ├── cw-asset 3.1.1
+            │   │   ├── astroport 5.0.0-rc.1-tokenfactory
+            │   │   │   ├── mars-zapper-astroport 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   ├── mars-swapper-astroport 2.0.0
+            │   │   │   ├── mars-oracle-wasm 2.0.0
+            │   │   │   ├── mars-mock-astroport-incentives 2.0.0
+            │   │   │   ├── mars-integration-tests 2.0.0
+            │   │   │   └── mars-incentives 2.0.0
+            │   │   └── astroport 3.11.1
+            │   ├── astroport-incentives 1.0.0
+            │   ├── astroport 5.0.0-rc.1-tokenfactory
+            │   ├── apollo-utils 0.1.2
+            │   │   ├── mars-zapper-astroport 2.0.0
+            │   │   └── cw-dex 0.3.1
+            │   └── apollo-cw-asset 0.1.2
+            │       ├── mars-zapper-astroport 2.0.0
+            │       ├── cw-dex 0.3.1
+            │       └── apollo-utils 0.1.2
+            ├── cw20 0.15.1
+            │   ├── cw20-base 0.15.1
+            │   ├── cw-it 0.3.0
+            │   ├── astroport-vesting 1.3.1
+            │   │   └── cw-it 0.3.0
+            │   ├── astroport-token 1.1.1
+            │   ├── astroport-staking 1.1.0
+            │   │   └── cw-it 0.3.0
+            │   ├── astroport-router 1.1.1
+            │   │   └── cw-it 0.3.0
+            │   ├── astroport-pair-stable 2.1.3
+            │   │   ├── cw-it 0.3.0
+            │   │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+            │   ├── astroport-pair-concentrated 1.2.7
+            │   │   └── cw-it 0.3.0
+            │   ├── astroport-pair 1.3.2
+            │   │   ├── cw-it 0.3.0
+            │   │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+            │   ├── astroport-maker 1.3.1
+            │   │   └── cw-it 0.3.0
+            │   ├── astroport-liquidity-manager 1.0.3-astroport-v2
+            │   ├── astroport-governance 1.2.0
+            │   │   ├── astroport-generator 2.3.0
+            │   │   │   └── cw-it 0.3.0
+            │   │   └── astro-satellite-package 0.1.0
+            │   │       └── astroport-maker 1.3.1
+            │   ├── astroport-generator 2.3.0
+            │   ├── astroport 3.11.1
+            │   └── astroport 2.9.0
+            │       ├── mars-testing 2.0.0
+            │       ├── mars-swapper-astroport 2.0.0
+            │       ├── mars-oracle-wasm 2.0.0
+            │       ├── cw-it 0.3.0
+            │       ├── astroport-whitelist 1.0.1
+            │       │   └── cw-it 0.3.0
+            │       ├── astroport-vesting 1.3.1
+            │       ├── astroport-token 1.1.1
+            │       ├── astroport-staking 1.1.0
+            │       ├── astroport-router 1.1.1
+            │       ├── astroport-pair-stable 2.1.3
+            │       ├── astroport-pair-concentrated 1.2.7
+            │       ├── astroport-pair 1.3.2
+            │       ├── astroport-native-coin-registry 1.0.1
+            │       │   └── cw-it 0.3.0
+            │       ├── astroport-maker 1.3.1
+            │       ├── astroport-liquidity-manager 1.0.3-astroport-v2
+            │       ├── astroport-governance 1.2.0
+            │       ├── astroport-generator 2.3.0
+            │       ├── astroport-factory 1.5.1
+            │       │   ├── cw-it 0.3.0
+            │       │   ├── astroport-pair-concentrated 1.2.7
+            │       │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+            │       └── apollo-cw-asset 0.1.2
+            ├── cw2 1.1.2
+            │   ├── mars-zapper-osmosis 2.0.0
+            │   ├── mars-zapper-base 2.0.0
+            │   ├── mars-zapper-astroport 2.0.0
+            │   ├── mars-vault 2.0.0
+            │   ├── mars-swapper-osmosis 2.0.3
+            │   ├── mars-swapper-base 2.0.0
+            │   ├── mars-swapper-astroport 2.0.0
+            │   ├── mars-rover-health 2.0.0
+            │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   ├── mars-rewards-collector-neutron 2.0.0
+            │   ├── mars-rewards-collector-base 2.0.0
+            │   ├── mars-red-bank 2.0.1
+            │   ├── mars-params 2.0.1
+            │   ├── mars-oracle-wasm 2.0.0
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-oracle-base 2.0.0
+            │   ├── mars-incentives 2.0.0
+            │   ├── mars-credit-manager 2.0.3
+            │   ├── mars-address-provider 2.0.0
+            │   ├── mars-account-nft 2.0.0
+            │   ├── ica-oracle 1.0.0
+            │   ├── cw721-base 0.18.0
+            │   ├── cw-utils 1.0.3
+            │   │   ├── mars-zapper-osmosis 2.0.0
+            │   │   ├── mars-zapper-mock 2.0.0
+            │   │   ├── mars-zapper-base 2.0.0
+            │   │   ├── mars-vault 2.0.0
+            │   │   ├── mars-types 2.0.0
+            │   │   ├── mars-testing 2.0.0
+            │   │   ├── mars-rover-health 2.0.0
+            │   │   ├── mars-rover 1.0.0
+            │   │   ├── mars-red-bank 2.0.1
+            │   │   ├── mars-mock-vault 2.0.0
+            │   │   ├── mars-mock-red-bank 2.0.0
+            │   │   ├── mars-mock-astroport-incentives 2.0.0
+            │   │   ├── mars-credit-manager 2.0.3
+            │   │   ├── cw721-base 0.18.0
+            │   │   ├── cw721 0.18.0
+            │   │   ├── cw3 1.1.1
+            │   │   ├── cw20 1.1.2
+            │   │   ├── cw-vault-standard 0.4.0
+            │   │   │   ├── mars-vault 2.0.0
+            │   │   │   ├── mars-types 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   ├── mars-rover-health 2.0.0
+            │   │   │   ├── mars-mock-vault 2.0.0
+            │   │   │   └── mars-credit-manager 2.0.3
+            │   │   ├── cw-vault-standard 0.2.0
+            │   │   │   └── mars-rover 1.0.0
+            │   │   ├── cw-ownable 0.5.1
+            │   │   │   └── cw721-base 0.18.0
+            │   │   ├── cw-multi-test 0.20.0
+            │   │   │   ├── mars-vault 2.0.0
+            │   │   │   ├── mars-testing 2.0.0
+            │   │   │   ├── mars-swapper-mock 2.0.0
+            │   │   │   ├── mars-rover-health 2.0.0
+            │   │   │   ├── mars-red-bank 2.0.1
+            │   │   │   ├── mars-params 2.0.1
+            │   │   │   ├── mars-integration-tests 2.0.0
+            │   │   │   ├── mars-credit-manager 2.0.3
+            │   │   │   └── mars-account-nft 2.0.0
+            │   │   ├── cw-dex 0.3.1
+            │   │   ├── astroport-pair-stable 2.1.3
+            │   │   ├── astroport-incentives 1.0.0
+            │   │   ├── astroport 5.0.0-rc.1-tokenfactory
+            │   │   ├── astroport 3.11.1
+            │   │   └── apollo-cw-multi-test 0.18.0
+            │   └── astroport-incentives 1.0.0
+            ├── cw2 0.16.0
+            │   ├── cw721-base 0.16.0
+            │   └── cw-utils 0.16.0
+            │       ├── cw721-base 0.16.0
+            │       └── cw721 0.16.0
+            ├── cw2 0.15.1
+            │   ├── cw20-base 0.15.1
+            │   ├── cw1-whitelist 0.15.1
+            │   │   ├── astroport-whitelist 1.0.1
+            │   │   └── astroport-generator 2.3.0
+            │   ├── cw-utils 0.15.1
+            │   │   ├── cw20-base 0.15.1
+            │   │   ├── cw20 0.15.1
+            │   │   ├── cw1-whitelist 0.15.1
+            │   │   ├── astroport-vesting 1.3.1
+            │   │   ├── astroport-pair-concentrated 1.2.7
+            │   │   └── astroport 2.9.0
+            │   ├── astroport-whitelist 1.0.1
+            │   ├── astroport-vesting 1.3.1
+            │   ├── astroport-token 1.1.1
+            │   ├── astroport-staking 1.1.0
+            │   ├── astroport-router 1.1.1
+            │   ├── astroport-pair-stable 2.1.3
+            │   ├── astroport-pair-concentrated 1.2.7
+            │   ├── astroport-pair 1.3.2
+            │   ├── astroport-native-coin-registry 1.0.1
+            │   ├── astroport-maker 1.3.1
+            │   ├── astroport-generator 2.3.0
+            │   └── astroport-factory 1.5.1
+            ├── cw1-whitelist 0.15.1
+            ├── cw1 0.15.1
+            │   └── cw1-whitelist 0.15.1
+            ├── cw-vault-standard 0.4.0
+            ├── cw-vault-standard 0.2.0
+            ├── cw-utils 1.0.3
+            ├── cw-utils 0.16.0
+            ├── cw-utils 0.15.1
+            ├── cw-storage-plus 1.2.0
+            │   ├── mars-zapper-mock 2.0.0
+            │   ├── mars-vault 2.0.0
+            │   ├── mars-utils 2.0.0
+            │   ├── mars-types 2.0.0
+            │   ├── mars-swapper-osmosis 2.0.3
+            │   ├── mars-swapper-base 2.0.0
+            │   ├── mars-rover-health 2.0.0
+            │   ├── mars-rover 1.0.0
+            │   ├── mars-rewards-collector-osmosis 2.0.1
+            │   ├── mars-rewards-collector-base 2.0.0
+            │   ├── mars-red-bank 2.0.1
+            │   ├── mars-params 2.0.1
+            │   ├── mars-owner 2.0.0
+            │   ├── mars-owner 1.2.0
+            │   ├── mars-oracle-wasm 2.0.0
+            │   ├── mars-oracle-osmosis 2.0.1
+            │   ├── mars-oracle-base 2.0.0
+            │   ├── mars-mock-vault 2.0.0
+            │   ├── mars-mock-rover-health 2.0.0
+            │   ├── mars-mock-red-bank 2.0.0
+            │   ├── mars-mock-oracle 2.0.0
+            │   ├── mars-mock-incentives 2.0.0
+            │   ├── mars-mock-credit-manager 2.0.0
+            │   ├── mars-mock-astroport-incentives 2.0.0
+            │   ├── mars-incentives 2.0.0
+            │   ├── mars-credit-manager 2.0.3
+            │   ├── mars-address-provider 2.0.0
+            │   ├── mars-account-nft 2.0.0
+            │   ├── ica-oracle 1.0.0
+            │   ├── cw721-base 0.18.0
+            │   ├── cw2 1.1.2
+            │   ├── cw-paginate 0.2.2
+            │   │   ├── mars-vault 2.0.0
+            │   │   ├── mars-types 2.0.0
+            │   │   ├── mars-testing 2.0.0
+            │   │   ├── mars-swapper-base 2.0.0
+            │   │   ├── mars-red-bank 2.0.1
+            │   │   ├── mars-params 2.0.1
+            │   │   ├── mars-mock-red-bank 2.0.0
+            │   │   ├── mars-mock-incentives 2.0.0
+            │   │   ├── mars-incentives 2.0.0
+            │   │   └── mars-credit-manager 2.0.3
+            │   ├── cw-ownable 0.5.1
+            │   ├── cw-multi-test 0.20.0
+            │   ├── cw-dex 0.3.1
+            │   ├── cw-asset 3.1.1
+            │   ├── astroport-liquidity-manager 1.0.3-astroport-v2
+            │   ├── astroport 5.0.0-rc.1-tokenfactory
+            │   ├── apollo-cw-multi-test 0.18.0
+            │   └── apollo-cw-asset 0.1.2
+            ├── cw-storage-plus 0.16.0
+            │   ├── cw721-base 0.16.0
+            │   └── cw2 0.16.0
+            ├── cw-storage-plus 0.15.1
+            │   ├── cw20-base 0.15.1
+            │   ├── cw2 0.15.1
+            │   ├── cw1-whitelist 0.15.1
+            │   ├── astroport-vesting 1.3.1
+            │   ├── astroport-staking 1.1.0
+            │   ├── astroport-router 1.1.1
+            │   ├── astroport-pair-stable 2.1.3
+            │   ├── astroport-pair-concentrated 1.2.7
+            │   ├── astroport-pair 1.3.2
+            │   ├── astroport-native-coin-registry 1.0.1
+            │   ├── astroport-maker 1.3.1
+            │   ├── astroport-incentives 1.0.0
+            │   ├── astroport-governance 1.2.0
+            │   ├── astroport-generator 2.3.0
+            │   ├── astroport-factory 1.5.1
+            │   ├── astroport-circular-buffer 0.2.0
+            │   │   └── astroport 5.0.0-rc.1-tokenfactory
+            │   ├── astroport-circular-buffer 0.1.0
+            │   │   └── astroport 3.11.1
+            │   ├── astroport 3.11.1
+            │   └── astroport 2.9.0
+            ├── cw-paginate 0.2.2
+            ├── cw-ownable 0.5.1
+            ├── cw-multi-test 0.20.0
+            ├── cw-it 0.3.0
+            ├── cw-dex 0.3.1
+            ├── cw-asset 3.1.1
+            ├── cw-address-like 1.0.4
+            │   ├── cw-ownable 0.5.1
+            │   └── cw-asset 3.1.1
+            ├── cosmwasm-storage 1.4.1
+            │   └── astroport-native-coin-registry 1.0.1
+            ├── astroport-whitelist 1.0.1
+            ├── astroport-vesting 1.3.1
+            ├── astroport-token 1.1.1
+            ├── astroport-staking 1.1.0
+            ├── astroport-router 1.1.1
+            ├── astroport-pair-stable 2.1.3
+            ├── astroport-pair-concentrated 1.2.7
+            ├── astroport-pair 1.3.2
+            ├── astroport-native-coin-registry 1.0.1
+            ├── astroport-maker 1.3.1
+            ├── astroport-liquidity-manager 1.0.3-astroport-v2
+            ├── astroport-incentives 1.0.0
+            ├── astroport-governance 1.2.0
+            ├── astroport-generator 2.3.0
+            ├── astroport-factory 1.5.1
+            ├── astroport-circular-buffer 0.2.0
+            ├── astroport-circular-buffer 0.1.0
+            ├── astroport 5.0.0-rc.1-tokenfactory
+            ├── astroport 3.11.1
+            ├── astroport 2.9.0
+            ├── astro-satellite-package 0.1.0
+            ├── apollo-utils 0.1.2
+            ├── apollo-cw-multi-test 0.18.0
+            └── apollo-cw-asset 0.1.2
+
+Crate:     yaml-rust
+Version:   0.4.5
+Warning:   unmaintained
+Title:     yaml-rust is unmaintained.
+Date:      2024-03-20
+ID:        RUSTSEC-2024-0320
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0320
+Dependency tree:
+yaml-rust 0.4.5
+└── config 0.13.3
+    └── cw-it 0.3.0
+        ├── mars-zapper-astroport 2.0.0
+        ├── mars-testing 2.0.0
+        │   ├── mars-zapper-astroport 2.0.0
+        │   ├── mars-vault 2.0.0
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-credit-manager 2.0.3
+        │   │       └── mars-testing 2.0.0
+        │   ├── mars-swapper-osmosis 2.0.3
+        │   │   └── mars-integration-tests 2.0.0
+        │   ├── mars-swapper-astroport 2.0.0
+        │   │   └── mars-testing 2.0.0
+        │   ├── mars-rewards-collector-osmosis 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-integration-tests 2.0.0
+        │   ├── mars-rewards-collector-neutron 2.0.0
+        │   ├── mars-red-bank 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   ├── mars-integration-tests 2.0.0
+        │   │   └── mars-incentives 2.0.0
+        │   │       ├── mars-testing 2.0.0
+        │   │       └── mars-integration-tests 2.0.0
+        │   ├── mars-params 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   ├── mars-rover-health 2.0.0
+        │   │   │   ├── mars-testing 2.0.0
+        │   │   │   └── mars-credit-manager 2.0.3
+        │   │   ├── mars-integration-tests 2.0.0
+        │   │   └── mars-credit-manager 2.0.3
+        │   ├── mars-oracle-wasm 2.0.0
+        │   │   ├── mars-zapper-astroport 2.0.0
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-swapper-astroport 2.0.0
+        │   ├── mars-oracle-osmosis 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-integration-tests 2.0.0
+        │   ├── mars-integration-tests 2.0.0
+        │   ├── mars-incentives 2.0.0
+        │   ├── mars-health 2.0.0
+        │   │   ├── mars-red-bank 2.0.1
+        │   │   └── mars-liquidation 1.0.0
+        │   │       ├── mars-red-bank 2.0.1
+        │   │       └── mars-credit-manager 2.0.3
+        │   ├── mars-credit-manager 2.0.3
+        │   └── mars-address-provider 2.0.0
+        │       ├── mars-testing 2.0.0
+        │       └── mars-credit-manager 2.0.3
+        ├── mars-swapper-osmosis 2.0.3
+        ├── mars-swapper-astroport 2.0.0
+        ├── mars-oracle-wasm 2.0.0
+        ├── mars-integration-tests 2.0.0
+        └── mars-incentives 2.0.0
+
+Crate:     borsh
+Version:   0.9.3
+Warning:   unsound
+Title:     Parsing borsh messages with ZST which are not-copy/clone is unsound
+Date:      2023-04-12
+ID:        RUSTSEC-2023-0033
+URL:       https://rustsec.org/advisories/RUSTSEC-2023-0033
+Dependency tree:
+borsh 0.9.3
+└── pyth-sdk 0.7.0
+    └── pyth-sdk-cw 1.2.0
+        ├── mars-testing 2.0.0
+        │   ├── mars-zapper-astroport 2.0.0
+        │   ├── mars-vault 2.0.0
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-credit-manager 2.0.3
+        │   │       └── mars-testing 2.0.0
+        │   ├── mars-swapper-osmosis 2.0.3
+        │   │   └── mars-integration-tests 2.0.0
+        │   ├── mars-swapper-astroport 2.0.0
+        │   │   └── mars-testing 2.0.0
+        │   ├── mars-rewards-collector-osmosis 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-integration-tests 2.0.0
+        │   ├── mars-rewards-collector-neutron 2.0.0
+        │   ├── mars-red-bank 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   ├── mars-integration-tests 2.0.0
+        │   │   └── mars-incentives 2.0.0
+        │   │       ├── mars-testing 2.0.0
+        │   │       └── mars-integration-tests 2.0.0
+        │   ├── mars-params 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   ├── mars-rover-health 2.0.0
+        │   │   │   ├── mars-testing 2.0.0
+        │   │   │   └── mars-credit-manager 2.0.3
+        │   │   ├── mars-integration-tests 2.0.0
+        │   │   └── mars-credit-manager 2.0.3
+        │   ├── mars-oracle-wasm 2.0.0
+        │   │   ├── mars-zapper-astroport 2.0.0
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-swapper-astroport 2.0.0
+        │   ├── mars-oracle-osmosis 2.0.1
+        │   │   ├── mars-testing 2.0.0
+        │   │   └── mars-integration-tests 2.0.0
+        │   ├── mars-integration-tests 2.0.0
+        │   ├── mars-incentives 2.0.0
+        │   ├── mars-health 2.0.0
+        │   │   ├── mars-red-bank 2.0.1
+        │   │   └── mars-liquidation 1.0.0
+        │   │       ├── mars-red-bank 2.0.1
+        │   │       └── mars-credit-manager 2.0.3
+        │   ├── mars-credit-manager 2.0.3
+        │   └── mars-address-provider 2.0.0
+        │       ├── mars-testing 2.0.0
+        │       └── mars-credit-manager 2.0.3
+        ├── mars-oracle-wasm 2.0.0
+        ├── mars-oracle-osmosis 2.0.1
+        ├── mars-oracle-base 2.0.0
+        │   ├── mars-oracle-wasm 2.0.0
+        │   ├── mars-oracle-osmosis 2.0.1
+        │   └── mars-integration-tests 2.0.0
+        └── mars-mock-pyth 2.0.0
+            └── mars-testing 2.0.0
+
+Crate:     ahash
+Version:   0.7.6
+Warning:   yanked
+Dependency tree:
+ahash 0.7.6
+├── hashbrown 0.12.3
+│   ├── ordered-multimap 0.4.3
+│   │   └── rust-ini 0.18.0
+│   │       └── config 0.13.3
+│   │           └── cw-it 0.3.0
+│   │               ├── mars-zapper-astroport 2.0.0
+│   │               ├── mars-testing 2.0.0
+│   │               │   ├── mars-zapper-astroport 2.0.0
+│   │               │   ├── mars-vault 2.0.0
+│   │               │   │   ├── mars-testing 2.0.0
+│   │               │   │   └── mars-credit-manager 2.0.3
+│   │               │   │       └── mars-testing 2.0.0
+│   │               │   ├── mars-swapper-osmosis 2.0.3
+│   │               │   │   └── mars-integration-tests 2.0.0
+│   │               │   ├── mars-swapper-astroport 2.0.0
+│   │               │   │   └── mars-testing 2.0.0
+│   │               │   ├── mars-rewards-collector-osmosis 2.0.1
+│   │               │   │   ├── mars-testing 2.0.0
+│   │               │   │   └── mars-integration-tests 2.0.0
+│   │               │   ├── mars-rewards-collector-neutron 2.0.0
+│   │               │   ├── mars-red-bank 2.0.1
+│   │               │   │   ├── mars-testing 2.0.0
+│   │               │   │   ├── mars-integration-tests 2.0.0
+│   │               │   │   └── mars-incentives 2.0.0
+│   │               │   │       ├── mars-testing 2.0.0
+│   │               │   │       └── mars-integration-tests 2.0.0
+│   │               │   ├── mars-params 2.0.1
+│   │               │   │   ├── mars-testing 2.0.0
+│   │               │   │   ├── mars-rover-health 2.0.0
+│   │               │   │   │   ├── mars-testing 2.0.0
+│   │               │   │   │   └── mars-credit-manager 2.0.3
+│   │               │   │   ├── mars-integration-tests 2.0.0
+│   │               │   │   └── mars-credit-manager 2.0.3
+│   │               │   ├── mars-oracle-wasm 2.0.0
+│   │               │   │   ├── mars-zapper-astroport 2.0.0
+│   │               │   │   ├── mars-testing 2.0.0
+│   │               │   │   └── mars-swapper-astroport 2.0.0
+│   │               │   ├── mars-oracle-osmosis 2.0.1
+│   │               │   │   ├── mars-testing 2.0.0
+│   │               │   │   └── mars-integration-tests 2.0.0
+│   │               │   ├── mars-integration-tests 2.0.0
+│   │               │   ├── mars-incentives 2.0.0
+│   │               │   ├── mars-health 2.0.0
+│   │               │   │   ├── mars-red-bank 2.0.1
+│   │               │   │   └── mars-liquidation 1.0.0
+│   │               │   │       ├── mars-red-bank 2.0.1
+│   │               │   │       └── mars-credit-manager 2.0.3
+│   │               │   ├── mars-credit-manager 2.0.3
+│   │               │   └── mars-address-provider 2.0.0
+│   │               │       ├── mars-testing 2.0.0
+│   │               │       └── mars-credit-manager 2.0.3
+│   │               ├── mars-swapper-osmosis 2.0.3
+│   │               ├── mars-swapper-astroport 2.0.0
+│   │               ├── mars-oracle-wasm 2.0.0
+│   │               ├── mars-integration-tests 2.0.0
+│   │               └── mars-incentives 2.0.0
+│   ├── indexmap 1.9.3
+│   │   └── h2 0.3.21
+│   │       ├── reqwest 0.11.24
+│   │       │   └── tendermint-rpc 0.34.1
+│   │       │       └── cosmrs 0.15.0
+│   │       │           ├── test-tube 0.5.0
+│   │       │           │   ├── osmosis-test-tube 22.1.0
+│   │       │           │   │   ├── mars-zapper-osmosis 2.0.0
+│   │       │           │   │   ├── mars-integration-tests 2.0.0
+│   │       │           │   │   └── cw-it 0.3.0
+│   │       │           │   └── cw-it 0.3.0
+│   │       │           ├── osmosis-test-tube 22.1.0
+│   │       │           └── cw-it 0.3.0
+│   │       └── hyper 0.14.27
+│   │           ├── reqwest 0.11.24
+│   │           └── hyper-rustls 0.24.2
+│   │               └── reqwest 0.11.24
+│   └── ed25519-zebra 3.1.0
+│       └── cosmwasm-crypto 1.5.5
+│           └── cosmwasm-std 1.5.5
+│               ├── test-tube 0.5.0
+│               ├── pyth-sdk-cw 1.2.0
+│               │   ├── mars-testing 2.0.0
+│               │   ├── mars-oracle-wasm 2.0.0
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-oracle-base 2.0.0
+│               │   │   ├── mars-oracle-wasm 2.0.0
+│               │   │   ├── mars-oracle-osmosis 2.0.1
+│               │   │   └── mars-integration-tests 2.0.0
+│               │   └── mars-mock-pyth 2.0.0
+│               │       └── mars-testing 2.0.0
+│               ├── osmosis-test-tube 22.1.0
+│               ├── osmosis-std 0.22.0
+│               │   ├── test-tube 0.5.0
+│               │   ├── osmosis-test-tube 22.1.0
+│               │   ├── mars-zapper-osmosis 2.0.0
+│               │   ├── mars-vault 2.0.0
+│               │   ├── mars-testing 2.0.0
+│               │   ├── mars-swapper-osmosis 2.0.3
+│               │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   ├── mars-osmosis 2.0.0
+│               │   │   ├── mars-swapper-osmosis 2.0.3
+│               │   │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   │   ├── mars-oracle-osmosis 2.0.1
+│               │   │   └── mars-integration-tests 2.0.0
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-integration-tests 2.0.0
+│               │   ├── mars-incentives 2.0.0
+│               │   ├── cw-it 0.3.0
+│               │   └── apollo-cw-multi-test 0.18.0
+│               │       └── cw-it 0.3.0
+│               ├── osmosis-std 0.16.2
+│               │   └── cw-dex 0.3.1
+│               │       ├── mars-zapper-osmosis 2.0.0
+│               │       ├── mars-zapper-base 2.0.0
+│               │       │   ├── mars-zapper-osmosis 2.0.0
+│               │       │   └── mars-zapper-astroport 2.0.0
+│               │       └── mars-zapper-astroport 2.0.0
+│               ├── neutron-sdk 0.10.0
+│               │   └── mars-rewards-collector-neutron 2.0.0
+│               ├── mars-zapper-osmosis 2.0.0
+│               ├── mars-zapper-mock 2.0.0
+│               │   ├── mars-testing 2.0.0
+│               │   └── mars-credit-manager 2.0.3
+│               ├── mars-zapper-base 2.0.0
+│               ├── mars-zapper-astroport 2.0.0
+│               ├── mars-vault 2.0.0
+│               ├── mars-utils 2.0.0
+│               │   ├── mars-types 2.0.0
+│               │   │   ├── mars-zapper-osmosis 2.0.0
+│               │   │   ├── mars-zapper-mock 2.0.0
+│               │   │   ├── mars-zapper-base 2.0.0
+│               │   │   ├── mars-zapper-astroport 2.0.0
+│               │   │   ├── mars-vault 2.0.0
+│               │   │   ├── mars-testing 2.0.0
+│               │   │   ├── mars-swapper-osmosis 2.0.3
+│               │   │   ├── mars-swapper-mock 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-swapper-base 2.0.0
+│               │   │   │   ├── mars-swapper-osmosis 2.0.3
+│               │   │   │   └── mars-swapper-astroport 2.0.0
+│               │   │   ├── mars-swapper-astroport 2.0.0
+│               │   │   ├── mars-rover-health-computer 2.0.0
+│               │   │   │   └── mars-rover-health 2.0.0
+│               │   │   ├── mars-rover-health 2.0.0
+│               │   │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   │   ├── mars-rewards-collector-neutron 2.0.0
+│               │   │   ├── mars-rewards-collector-base 2.0.0
+│               │   │   │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   │   │   └── mars-rewards-collector-neutron 2.0.0
+│               │   │   ├── mars-red-bank 2.0.1
+│               │   │   ├── mars-params 2.0.1
+│               │   │   ├── mars-oracle-wasm 2.0.0
+│               │   │   ├── mars-oracle-osmosis 2.0.1
+│               │   │   ├── mars-oracle-base 2.0.0
+│               │   │   ├── mars-mock-vault 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   ├── mars-rover-health 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-mock-rover-health 2.0.0
+│               │   │   │   └── mars-account-nft 2.0.0
+│               │   │   │       ├── mars-testing 2.0.0
+│               │   │   │       └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-mock-red-bank 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-mock-oracle 2.0.0
+│               │   │   │   ├── mars-vault 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   ├── mars-rover-health 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-mock-incentives 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-mock-credit-manager 2.0.0
+│               │   │   │   ├── mars-rover-health 2.0.0
+│               │   │   │   └── mars-account-nft 2.0.0
+│               │   │   ├── mars-mock-astroport-incentives 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── mars-liquidation 1.0.0
+│               │   │   ├── mars-interest-rate 2.0.0
+│               │   │   │   ├── mars-red-bank 2.0.1
+│               │   │   │   └── mars-params 2.0.1
+│               │   │   ├── mars-integration-tests 2.0.0
+│               │   │   ├── mars-incentives 2.0.0
+│               │   │   ├── mars-health 2.0.0
+│               │   │   ├── mars-credit-manager 2.0.3
+│               │   │   ├── mars-address-provider 2.0.0
+│               │   │   └── mars-account-nft 2.0.0
+│               │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   ├── mars-rewards-collector-base 2.0.0
+│               │   ├── mars-red-bank 2.0.1
+│               │   ├── mars-params 2.0.1
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-oracle-base 2.0.0
+│               │   ├── mars-integration-tests 2.0.0
+│               │   ├── mars-incentives 2.0.0
+│               │   └── mars-credit-manager 2.0.3
+│               ├── mars-utils 1.0.0
+│               ├── mars-utils 1.0.0
+│               │   └── mars-red-bank-types 1.0.0
+│               │       └── mars-rover 1.0.0
+│               │           └── mars-account-nft 2.0.0
+│               ├── mars-types 2.0.0
+│               ├── mars-testing 2.0.0
+│               ├── mars-swapper-osmosis 2.0.3
+│               ├── mars-swapper-mock 2.0.0
+│               ├── mars-swapper-base 2.0.0
+│               ├── mars-swapper-astroport 2.0.0
+│               ├── mars-rover-health-computer 2.0.0
+│               ├── mars-rover-health 2.0.0
+│               ├── mars-rover 1.0.0
+│               ├── mars-rewards-collector-osmosis 2.0.1
+│               ├── mars-rewards-collector-neutron 2.0.0
+│               ├── mars-rewards-collector-base 2.0.0
+│               ├── mars-red-bank-types 1.0.0
+│               ├── mars-red-bank-types 1.0.0
+│               ├── mars-red-bank 2.0.1
+│               ├── mars-params 2.0.1
+│               ├── mars-owner 2.0.0
+│               │   ├── mars-vault 2.0.0
+│               │   ├── mars-types 2.0.0
+│               │   ├── mars-testing 2.0.0
+│               │   ├── mars-swapper-osmosis 2.0.3
+│               │   ├── mars-swapper-base 2.0.0
+│               │   ├── mars-rover-health 2.0.0
+│               │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   ├── mars-rewards-collector-base 2.0.0
+│               │   ├── mars-red-bank 2.0.1
+│               │   ├── mars-params 2.0.1
+│               │   ├── mars-oracle-wasm 2.0.0
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-oracle-base 2.0.0
+│               │   ├── mars-incentives 2.0.0
+│               │   ├── mars-credit-manager 2.0.3
+│               │   ├── mars-address-provider 2.0.0
+│               │   └── mars-account-nft 2.0.0
+│               ├── mars-owner 1.2.0
+│               │   ├── mars-rover 1.0.0
+│               │   ├── mars-red-bank-types 1.0.0
+│               │   └── mars-red-bank-types 1.0.0
+│               ├── mars-osmosis 2.0.0
+│               ├── mars-oracle-wasm 2.0.0
+│               ├── mars-oracle-osmosis 2.0.1
+│               ├── mars-oracle-base 2.0.0
+│               ├── mars-mock-vault 2.0.0
+│               ├── mars-mock-rover-health 2.0.0
+│               ├── mars-mock-red-bank 2.0.0
+│               ├── mars-mock-pyth 2.0.0
+│               ├── mars-mock-oracle 2.0.0
+│               ├── mars-mock-incentives 2.0.0
+│               ├── mars-mock-credit-manager 2.0.0
+│               ├── mars-mock-astroport-incentives 2.0.0
+│               ├── mars-liquidation 1.0.0
+│               ├── mars-interest-rate 2.0.0
+│               ├── mars-integration-tests 2.0.0
+│               ├── mars-incentives 2.0.0
+│               ├── mars-health 2.0.0
+│               ├── mars-health 1.0.0
+│               │   └── mars-rover 1.0.0
+│               ├── mars-credit-manager 2.0.3
+│               ├── mars-address-provider 2.0.0
+│               ├── mars-account-nft 2.0.0
+│               ├── ica-oracle 1.0.0
+│               │   ├── mars-testing 2.0.0
+│               │   ├── mars-oracle-wasm 2.0.0
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-oracle-base 2.0.0
+│               │   └── mars-integration-tests 2.0.0
+│               ├── cw721-base 0.18.0
+│               │   ├── mars-types 2.0.0
+│               │   ├── mars-testing 2.0.0
+│               │   ├── mars-credit-manager 2.0.3
+│               │   └── mars-account-nft 2.0.0
+│               ├── cw721-base 0.16.0
+│               │   ├── mars-rover 1.0.0
+│               │   ├── mars-account-nft 2.0.0
+│               │   └── cw721-base 0.18.0
+│               ├── cw721 0.18.0
+│               │   ├── mars-types 2.0.0
+│               │   ├── mars-testing 2.0.0
+│               │   ├── mars-credit-manager 2.0.3
+│               │   ├── mars-account-nft 2.0.0
+│               │   └── cw721-base 0.18.0
+│               ├── cw721 0.16.0
+│               │   ├── mars-rover 1.0.0
+│               │   └── cw721-base 0.16.0
+│               ├── cw3 1.1.1
+│               │   └── astroport 3.11.1
+│               │       ├── cw-it 0.3.0
+│               │       └── astroport-incentives 1.0.0
+│               │           └── cw-it 0.3.0
+│               ├── cw20-base 0.15.1
+│               │   ├── astroport-token 1.1.1
+│               │   │   └── cw-it 0.3.0
+│               │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │       └── cw-it 0.3.0
+│               ├── cw20 1.1.2
+│               │   ├── cw3 1.1.1
+│               │   ├── cw-dex 0.3.1
+│               │   ├── cw-asset 3.1.1
+│               │   │   ├── astroport 5.0.0-rc.1-tokenfactory
+│               │   │   │   ├── mars-zapper-astroport 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   ├── mars-swapper-astroport 2.0.0
+│               │   │   │   ├── mars-oracle-wasm 2.0.0
+│               │   │   │   ├── mars-mock-astroport-incentives 2.0.0
+│               │   │   │   ├── mars-integration-tests 2.0.0
+│               │   │   │   └── mars-incentives 2.0.0
+│               │   │   └── astroport 3.11.1
+│               │   ├── astroport-incentives 1.0.0
+│               │   ├── astroport 5.0.0-rc.1-tokenfactory
+│               │   ├── apollo-utils 0.1.2
+│               │   │   ├── mars-zapper-astroport 2.0.0
+│               │   │   └── cw-dex 0.3.1
+│               │   └── apollo-cw-asset 0.1.2
+│               │       ├── mars-zapper-astroport 2.0.0
+│               │       ├── cw-dex 0.3.1
+│               │       └── apollo-utils 0.1.2
+│               ├── cw20 0.15.1
+│               │   ├── cw20-base 0.15.1
+│               │   ├── cw-it 0.3.0
+│               │   ├── astroport-vesting 1.3.1
+│               │   │   └── cw-it 0.3.0
+│               │   ├── astroport-token 1.1.1
+│               │   ├── astroport-staking 1.1.0
+│               │   │   └── cw-it 0.3.0
+│               │   ├── astroport-router 1.1.1
+│               │   │   └── cw-it 0.3.0
+│               │   ├── astroport-pair-stable 2.1.3
+│               │   │   ├── cw-it 0.3.0
+│               │   │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │   ├── astroport-pair-concentrated 1.2.7
+│               │   │   └── cw-it 0.3.0
+│               │   ├── astroport-pair 1.3.2
+│               │   │   ├── cw-it 0.3.0
+│               │   │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │   ├── astroport-maker 1.3.1
+│               │   │   └── cw-it 0.3.0
+│               │   ├── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │   ├── astroport-governance 1.2.0
+│               │   │   ├── astroport-generator 2.3.0
+│               │   │   │   └── cw-it 0.3.0
+│               │   │   └── astro-satellite-package 0.1.0
+│               │   │       └── astroport-maker 1.3.1
+│               │   ├── astroport-generator 2.3.0
+│               │   ├── astroport 3.11.1
+│               │   └── astroport 2.9.0
+│               │       ├── mars-testing 2.0.0
+│               │       ├── mars-swapper-astroport 2.0.0
+│               │       ├── mars-oracle-wasm 2.0.0
+│               │       ├── cw-it 0.3.0
+│               │       ├── astroport-whitelist 1.0.1
+│               │       │   └── cw-it 0.3.0
+│               │       ├── astroport-vesting 1.3.1
+│               │       ├── astroport-token 1.1.1
+│               │       ├── astroport-staking 1.1.0
+│               │       ├── astroport-router 1.1.1
+│               │       ├── astroport-pair-stable 2.1.3
+│               │       ├── astroport-pair-concentrated 1.2.7
+│               │       ├── astroport-pair 1.3.2
+│               │       ├── astroport-native-coin-registry 1.0.1
+│               │       │   └── cw-it 0.3.0
+│               │       ├── astroport-maker 1.3.1
+│               │       ├── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │       ├── astroport-governance 1.2.0
+│               │       ├── astroport-generator 2.3.0
+│               │       ├── astroport-factory 1.5.1
+│               │       │   ├── cw-it 0.3.0
+│               │       │   ├── astroport-pair-concentrated 1.2.7
+│               │       │   └── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │       └── apollo-cw-asset 0.1.2
+│               ├── cw2 1.1.2
+│               │   ├── mars-zapper-osmosis 2.0.0
+│               │   ├── mars-zapper-base 2.0.0
+│               │   ├── mars-zapper-astroport 2.0.0
+│               │   ├── mars-vault 2.0.0
+│               │   ├── mars-swapper-osmosis 2.0.3
+│               │   ├── mars-swapper-base 2.0.0
+│               │   ├── mars-swapper-astroport 2.0.0
+│               │   ├── mars-rover-health 2.0.0
+│               │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   ├── mars-rewards-collector-neutron 2.0.0
+│               │   ├── mars-rewards-collector-base 2.0.0
+│               │   ├── mars-red-bank 2.0.1
+│               │   ├── mars-params 2.0.1
+│               │   ├── mars-oracle-wasm 2.0.0
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-oracle-base 2.0.0
+│               │   ├── mars-incentives 2.0.0
+│               │   ├── mars-credit-manager 2.0.3
+│               │   ├── mars-address-provider 2.0.0
+│               │   ├── mars-account-nft 2.0.0
+│               │   ├── ica-oracle 1.0.0
+│               │   ├── cw721-base 0.18.0
+│               │   ├── cw-utils 1.0.3
+│               │   │   ├── mars-zapper-osmosis 2.0.0
+│               │   │   ├── mars-zapper-mock 2.0.0
+│               │   │   ├── mars-zapper-base 2.0.0
+│               │   │   ├── mars-vault 2.0.0
+│               │   │   ├── mars-types 2.0.0
+│               │   │   ├── mars-testing 2.0.0
+│               │   │   ├── mars-rover-health 2.0.0
+│               │   │   ├── mars-rover 1.0.0
+│               │   │   ├── mars-red-bank 2.0.1
+│               │   │   ├── mars-mock-vault 2.0.0
+│               │   │   ├── mars-mock-red-bank 2.0.0
+│               │   │   ├── mars-mock-astroport-incentives 2.0.0
+│               │   │   ├── mars-credit-manager 2.0.3
+│               │   │   ├── cw721-base 0.18.0
+│               │   │   ├── cw721 0.18.0
+│               │   │   ├── cw3 1.1.1
+│               │   │   ├── cw20 1.1.2
+│               │   │   ├── cw-vault-standard 0.4.0
+│               │   │   │   ├── mars-vault 2.0.0
+│               │   │   │   ├── mars-types 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   ├── mars-rover-health 2.0.0
+│               │   │   │   ├── mars-mock-vault 2.0.0
+│               │   │   │   └── mars-credit-manager 2.0.3
+│               │   │   ├── cw-vault-standard 0.2.0
+│               │   │   │   └── mars-rover 1.0.0
+│               │   │   ├── cw-ownable 0.5.1
+│               │   │   │   └── cw721-base 0.18.0
+│               │   │   ├── cw-multi-test 0.20.0
+│               │   │   │   ├── mars-vault 2.0.0
+│               │   │   │   ├── mars-testing 2.0.0
+│               │   │   │   ├── mars-swapper-mock 2.0.0
+│               │   │   │   ├── mars-rover-health 2.0.0
+│               │   │   │   ├── mars-red-bank 2.0.1
+│               │   │   │   ├── mars-params 2.0.1
+│               │   │   │   ├── mars-integration-tests 2.0.0
+│               │   │   │   ├── mars-credit-manager 2.0.3
+│               │   │   │   └── mars-account-nft 2.0.0
+│               │   │   ├── cw-dex 0.3.1
+│               │   │   ├── astroport-pair-stable 2.1.3
+│               │   │   ├── astroport-incentives 1.0.0
+│               │   │   ├── astroport 5.0.0-rc.1-tokenfactory
+│               │   │   ├── astroport 3.11.1
+│               │   │   └── apollo-cw-multi-test 0.18.0
+│               │   └── astroport-incentives 1.0.0
+│               ├── cw2 0.16.0
+│               │   ├── cw721-base 0.16.0
+│               │   └── cw-utils 0.16.0
+│               │       ├── cw721-base 0.16.0
+│               │       └── cw721 0.16.0
+│               ├── cw2 0.15.1
+│               │   ├── cw20-base 0.15.1
+│               │   ├── cw1-whitelist 0.15.1
+│               │   │   ├── astroport-whitelist 1.0.1
+│               │   │   └── astroport-generator 2.3.0
+│               │   ├── cw-utils 0.15.1
+│               │   │   ├── cw20-base 0.15.1
+│               │   │   ├── cw20 0.15.1
+│               │   │   ├── cw1-whitelist 0.15.1
+│               │   │   ├── astroport-vesting 1.3.1
+│               │   │   ├── astroport-pair-concentrated 1.2.7
+│               │   │   └── astroport 2.9.0
+│               │   ├── astroport-whitelist 1.0.1
+│               │   ├── astroport-vesting 1.3.1
+│               │   ├── astroport-token 1.1.1
+│               │   ├── astroport-staking 1.1.0
+│               │   ├── astroport-router 1.1.1
+│               │   ├── astroport-pair-stable 2.1.3
+│               │   ├── astroport-pair-concentrated 1.2.7
+│               │   ├── astroport-pair 1.3.2
+│               │   ├── astroport-native-coin-registry 1.0.1
+│               │   ├── astroport-maker 1.3.1
+│               │   ├── astroport-generator 2.3.0
+│               │   └── astroport-factory 1.5.1
+│               ├── cw1-whitelist 0.15.1
+│               ├── cw1 0.15.1
+│               │   └── cw1-whitelist 0.15.1
+│               ├── cw-vault-standard 0.4.0
+│               ├── cw-vault-standard 0.2.0
+│               ├── cw-utils 1.0.3
+│               ├── cw-utils 0.16.0
+│               ├── cw-utils 0.15.1
+│               ├── cw-storage-plus 1.2.0
+│               │   ├── mars-zapper-mock 2.0.0
+│               │   ├── mars-vault 2.0.0
+│               │   ├── mars-utils 2.0.0
+│               │   ├── mars-types 2.0.0
+│               │   ├── mars-swapper-osmosis 2.0.3
+│               │   ├── mars-swapper-base 2.0.0
+│               │   ├── mars-rover-health 2.0.0
+│               │   ├── mars-rover 1.0.0
+│               │   ├── mars-rewards-collector-osmosis 2.0.1
+│               │   ├── mars-rewards-collector-base 2.0.0
+│               │   ├── mars-red-bank 2.0.1
+│               │   ├── mars-params 2.0.1
+│               │   ├── mars-owner 2.0.0
+│               │   ├── mars-owner 1.2.0
+│               │   ├── mars-oracle-wasm 2.0.0
+│               │   ├── mars-oracle-osmosis 2.0.1
+│               │   ├── mars-oracle-base 2.0.0
+│               │   ├── mars-mock-vault 2.0.0
+│               │   ├── mars-mock-rover-health 2.0.0
+│               │   ├── mars-mock-red-bank 2.0.0
+│               │   ├── mars-mock-oracle 2.0.0
+│               │   ├── mars-mock-incentives 2.0.0
+│               │   ├── mars-mock-credit-manager 2.0.0
+│               │   ├── mars-mock-astroport-incentives 2.0.0
+│               │   ├── mars-incentives 2.0.0
+│               │   ├── mars-credit-manager 2.0.3
+│               │   ├── mars-address-provider 2.0.0
+│               │   ├── mars-account-nft 2.0.0
+│               │   ├── ica-oracle 1.0.0
+│               │   ├── cw721-base 0.18.0
+│               │   ├── cw2 1.1.2
+│               │   ├── cw-paginate 0.2.2
+│               │   │   ├── mars-vault 2.0.0
+│               │   │   ├── mars-types 2.0.0
+│               │   │   ├── mars-testing 2.0.0
+│               │   │   ├── mars-swapper-base 2.0.0
+│               │   │   ├── mars-red-bank 2.0.1
+│               │   │   ├── mars-params 2.0.1
+│               │   │   ├── mars-mock-red-bank 2.0.0
+│               │   │   ├── mars-mock-incentives 2.0.0
+│               │   │   ├── mars-incentives 2.0.0
+│               │   │   └── mars-credit-manager 2.0.3
+│               │   ├── cw-ownable 0.5.1
+│               │   ├── cw-multi-test 0.20.0
+│               │   ├── cw-dex 0.3.1
+│               │   ├── cw-asset 3.1.1
+│               │   ├── astroport-liquidity-manager 1.0.3-astroport-v2
+│               │   ├── astroport 5.0.0-rc.1-tokenfactory
+│               │   ├── apollo-cw-multi-test 0.18.0
+│               │   └── apollo-cw-asset 0.1.2
+│               ├── cw-storage-plus 0.16.0
+│               │   ├── cw721-base 0.16.0
+│               │   └── cw2 0.16.0
+│               ├── cw-storage-plus 0.15.1
+│               │   ├── cw20-base 0.15.1
+│               │   ├── cw2 0.15.1
+│               │   ├── cw1-whitelist 0.15.1
+│               │   ├── astroport-vesting 1.3.1
+│               │   ├── astroport-staking 1.1.0
+│               │   ├── astroport-router 1.1.1
+│               │   ├── astroport-pair-stable 2.1.3
+│               │   ├── astroport-pair-concentrated 1.2.7
+│               │   ├── astroport-pair 1.3.2
+│               │   ├── astroport-native-coin-registry 1.0.1
+│               │   ├── astroport-maker 1.3.1
+│               │   ├── astroport-incentives 1.0.0
+│               │   ├── astroport-governance 1.2.0
+│               │   ├── astroport-generator 2.3.0
+│               │   ├── astroport-factory 1.5.1
+│               │   ├── astroport-circular-buffer 0.2.0
+│               │   │   └── astroport 5.0.0-rc.1-tokenfactory
+│               │   ├── astroport-circular-buffer 0.1.0
+│               │   │   └── astroport 3.11.1
+│               │   ├── astroport 3.11.1
+│               │   └── astroport 2.9.0
+│               ├── cw-paginate 0.2.2
+│               ├── cw-ownable 0.5.1
+│               ├── cw-multi-test 0.20.0
+│               ├── cw-it 0.3.0
+│               ├── cw-dex 0.3.1
+│               ├── cw-asset 3.1.1
+│               ├── cw-address-like 1.0.4
+│               │   ├── cw-ownable 0.5.1
+│               │   └── cw-asset 3.1.1
+│               ├── cosmwasm-storage 1.4.1
+│               │   └── astroport-native-coin-registry 1.0.1
+│               ├── astroport-whitelist 1.0.1
+│               ├── astroport-vesting 1.3.1
+│               ├── astroport-token 1.1.1
+│               ├── astroport-staking 1.1.0
+│               ├── astroport-router 1.1.1
+│               ├── astroport-pair-stable 2.1.3
+│               ├── astroport-pair-concentrated 1.2.7
+│               ├── astroport-pair 1.3.2
+│               ├── astroport-native-coin-registry 1.0.1
+│               ├── astroport-maker 1.3.1
+│               ├── astroport-liquidity-manager 1.0.3-astroport-v2
+│               ├── astroport-incentives 1.0.0
+│               ├── astroport-governance 1.2.0
+│               ├── astroport-generator 2.3.0
+│               ├── astroport-factory 1.5.1
+│               ├── astroport-circular-buffer 0.2.0
+│               ├── astroport-circular-buffer 0.1.0
+│               ├── astroport 5.0.0-rc.1-tokenfactory
+│               ├── astroport 3.11.1
+│               ├── astroport 2.9.0
+│               ├── astro-satellite-package 0.1.0
+│               ├── apollo-utils 0.1.2
+│               ├── apollo-cw-multi-test 0.18.0
+│               └── apollo-cw-asset 0.1.2
+└── hashbrown 0.11.2
+    └── borsh 0.9.3
+        └── pyth-sdk 0.7.0
+            └── pyth-sdk-cw 1.2.0
+
+Crate:     cw-vault-standard
+Version:   0.4.0
+Warning:   yanked
+Dependency tree:
+cw-vault-standard 0.4.0
+├── mars-vault 2.0.0
+│   ├── mars-testing 2.0.0
+│   │   ├── mars-zapper-astroport 2.0.0
+│   │   ├── mars-vault 2.0.0
+│   │   ├── mars-swapper-osmosis 2.0.3
+│   │   │   └── mars-integration-tests 2.0.0
+│   │   ├── mars-swapper-astroport 2.0.0
+│   │   │   └── mars-testing 2.0.0
+│   │   ├── mars-rewards-collector-osmosis 2.0.1
+│   │   │   ├── mars-testing 2.0.0
+│   │   │   └── mars-integration-tests 2.0.0
+│   │   ├── mars-rewards-collector-neutron 2.0.0
+│   │   ├── mars-red-bank 2.0.1
+│   │   │   ├── mars-testing 2.0.0
+│   │   │   ├── mars-integration-tests 2.0.0
+│   │   │   └── mars-incentives 2.0.0
+│   │   │       ├── mars-testing 2.0.0
+│   │   │       └── mars-integration-tests 2.0.0
+│   │   ├── mars-params 2.0.1
+│   │   │   ├── mars-testing 2.0.0
+│   │   │   ├── mars-rover-health 2.0.0
+│   │   │   │   ├── mars-testing 2.0.0
+│   │   │   │   └── mars-credit-manager 2.0.3
+│   │   │   │       └── mars-testing 2.0.0
+│   │   │   ├── mars-integration-tests 2.0.0
+│   │   │   └── mars-credit-manager 2.0.3
+│   │   ├── mars-oracle-wasm 2.0.0
+│   │   │   ├── mars-zapper-astroport 2.0.0
+│   │   │   ├── mars-testing 2.0.0
+│   │   │   └── mars-swapper-astroport 2.0.0
+│   │   ├── mars-oracle-osmosis 2.0.1
+│   │   │   ├── mars-testing 2.0.0
+│   │   │   └── mars-integration-tests 2.0.0
+│   │   ├── mars-integration-tests 2.0.0
+│   │   ├── mars-incentives 2.0.0
+│   │   ├── mars-health 2.0.0
+│   │   │   ├── mars-red-bank 2.0.1
+│   │   │   └── mars-liquidation 1.0.0
+│   │   │       ├── mars-red-bank 2.0.1
+│   │   │       └── mars-credit-manager 2.0.3
+│   │   ├── mars-credit-manager 2.0.3
+│   │   └── mars-address-provider 2.0.0
+│   │       ├── mars-testing 2.0.0
+│   │       └── mars-credit-manager 2.0.3
+│   └── mars-credit-manager 2.0.3
+├── mars-types 2.0.0
+│   ├── mars-zapper-osmosis 2.0.0
+│   ├── mars-zapper-mock 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-zapper-base 2.0.0
+│   │   ├── mars-zapper-osmosis 2.0.0
+│   │   └── mars-zapper-astroport 2.0.0
+│   ├── mars-zapper-astroport 2.0.0
+│   ├── mars-vault 2.0.0
+│   ├── mars-testing 2.0.0
+│   ├── mars-swapper-osmosis 2.0.3
+│   ├── mars-swapper-mock 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-swapper-base 2.0.0
+│   │   ├── mars-swapper-osmosis 2.0.3
+│   │   └── mars-swapper-astroport 2.0.0
+│   ├── mars-swapper-astroport 2.0.0
+│   ├── mars-rover-health-computer 2.0.0
+│   │   └── mars-rover-health 2.0.0
+│   ├── mars-rover-health 2.0.0
+│   ├── mars-rewards-collector-osmosis 2.0.1
+│   ├── mars-rewards-collector-neutron 2.0.0
+│   ├── mars-rewards-collector-base 2.0.0
+│   │   ├── mars-rewards-collector-osmosis 2.0.1
+│   │   └── mars-rewards-collector-neutron 2.0.0
+│   ├── mars-red-bank 2.0.1
+│   ├── mars-params 2.0.1
+│   ├── mars-oracle-wasm 2.0.0
+│   ├── mars-oracle-osmosis 2.0.1
+│   ├── mars-oracle-base 2.0.0
+│   │   ├── mars-oracle-wasm 2.0.0
+│   │   ├── mars-oracle-osmosis 2.0.1
+│   │   └── mars-integration-tests 2.0.0
+│   ├── mars-mock-vault 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   ├── mars-rover-health 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-mock-rover-health 2.0.0
+│   │   └── mars-account-nft 2.0.0
+│   │       ├── mars-testing 2.0.0
+│   │       └── mars-credit-manager 2.0.3
+│   ├── mars-mock-red-bank 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-mock-oracle 2.0.0
+│   │   ├── mars-vault 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   ├── mars-rover-health 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-mock-incentives 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-mock-credit-manager 2.0.0
+│   │   ├── mars-rover-health 2.0.0
+│   │   └── mars-account-nft 2.0.0
+│   ├── mars-mock-astroport-incentives 2.0.0
+│   │   ├── mars-testing 2.0.0
+│   │   └── mars-credit-manager 2.0.3
+│   ├── mars-liquidation 1.0.0
+│   ├── mars-interest-rate 2.0.0
+│   │   ├── mars-red-bank 2.0.1
+│   │   └── mars-params 2.0.1
+│   ├── mars-integration-tests 2.0.0
+│   ├── mars-incentives 2.0.0
+│   ├── mars-health 2.0.0
+│   ├── mars-credit-manager 2.0.3
+│   ├── mars-address-provider 2.0.0
+│   └── mars-account-nft 2.0.0
+├── mars-testing 2.0.0
+├── mars-rover-health 2.0.0
+├── mars-mock-vault 2.0.0
+└── mars-credit-manager 2.0.3
+
+warning: 4 allowed warnings found
+[cargo-make] ERROR - Error while executing command, exit code: 1
+[cargo-make] WARN - Build Failed.

--- a/contracts/credit-manager/src/claim_astro_lp_rewards.rs
+++ b/contracts/credit-manager/src/claim_astro_lp_rewards.rs
@@ -25,14 +25,11 @@ pub fn claim_lp_rewards(
     }
 
     let claim_rewards_msg = incentives.claim_staked_astro_lp_rewards_msg(account_id, lp_denom)?;
-    let mut res = Response::new()
+    let res = Response::new()
         .add_message(claim_rewards_msg)
         .add_attribute("action", "claim_astro_lp_rewards")
-        .add_attribute("account_id", account_id);
-
-    if !rewards.is_empty() {
-        res = res.add_attribute("rewards", rewards.as_slice().to_string());
-    }
+        .add_attribute("account_id", account_id)
+        .add_attribute("rewards", rewards.as_slice().to_string());
 
     Ok(res)
 }

--- a/contracts/credit-manager/src/claim_rewards.rs
+++ b/contracts/credit-manager/src/claim_rewards.rs
@@ -1,24 +1,13 @@
-use cosmwasm_std::{
-    to_json_binary, Addr, BankMsg, Coin, CosmosMsg, DepsMut, Env, QuerierWrapper, Response,
-    StdResult, WasmMsg,
-};
-use mars_types::{
-    credit_manager::{CallbackMsg, ExecuteMsg},
-    traits::Denoms,
-};
+use cosmwasm_std::{DepsMut, Response};
+use mars_types::traits::Stringify;
 
 use crate::{
     error::{ContractError, ContractResult},
     state::INCENTIVES,
-    update_coin_balances::query_balance,
+    utils::increment_coin_balance,
 };
 
-pub fn claim_rewards(
-    deps: DepsMut,
-    env: Env,
-    account_id: &str,
-    recipient: Addr,
-) -> ContractResult<Response> {
+pub fn claim_rewards(deps: DepsMut, account_id: &str) -> ContractResult<Response> {
     let incentives = INCENTIVES.load(deps.storage)?;
 
     let unclaimed_rewards = incentives.query_unclaimed_rewards(&deps.querier, account_id)?;
@@ -26,77 +15,13 @@ pub fn claim_rewards(
         return Err(ContractError::NoAmount);
     }
 
-    // Incentive denom may not be listed in params contract.
-    // When rewards are claimed to the account, they are considered deposits (collateral).
-    // If the account requires HF check, health contract won't be able to find
-    // incentive denom params (such as MaxLTV) for HF calculation and the TX will be rejected.
-    // To address this issue we withdraw all claimed rewards to the recipient address.
-    let msg = send_rewards_msg(
-        &deps.querier,
-        &env.contract.address,
-        account_id,
-        recipient.clone(),
-        unclaimed_rewards.to_denoms(),
-    )?;
+    for reward in unclaimed_rewards.iter() {
+        increment_coin_balance(deps.storage, account_id, reward)?;
+    }
 
     Ok(Response::new()
         .add_message(incentives.claim_rewards_msg(account_id)?)
-        .add_message(msg)
         .add_attribute("action", "claim_rewards")
         .add_attribute("account_id", account_id)
-        .add_attribute("recipient", recipient.to_string()))
-}
-
-fn send_rewards_msg(
-    querier: &QuerierWrapper,
-    credit_manager_addr: &Addr,
-    account_id: &str,
-    recipient: Addr,
-    denoms: Vec<&str>,
-) -> StdResult<CosmosMsg> {
-    let coins = denoms
-        .iter()
-        .map(|denom| query_balance(querier, credit_manager_addr, denom))
-        .collect::<StdResult<Vec<_>>>()?;
-    Ok(CosmosMsg::Wasm(WasmMsg::Execute {
-        contract_addr: credit_manager_addr.to_string(),
-        funds: vec![],
-        msg: to_json_binary(&ExecuteMsg::Callback(CallbackMsg::SendRewardsToAddr {
-            account_id: account_id.to_string(),
-            previous_balances: coins,
-            recipient,
-        }))?,
-    }))
-}
-
-pub fn send_rewards(
-    deps: DepsMut,
-    credit_manager_addr: &Addr,
-    account_id: &str,
-    recipient: Addr,
-    previous_balances: Vec<Coin>,
-) -> ContractResult<Response> {
-    let coins = previous_balances
-        .into_iter()
-        .map(|coin| {
-            let current_balance = query_balance(&deps.querier, credit_manager_addr, &coin.denom)?;
-            let amount_to_withdraw = current_balance.amount.checked_sub(coin.amount)?;
-            Ok(Coin {
-                denom: coin.denom,
-                amount: amount_to_withdraw,
-            })
-        })
-        .collect::<StdResult<Vec<_>>>()?;
-
-    // send coin to recipient
-    let transfer_msg = CosmosMsg::Bank(BankMsg::Send {
-        to_address: recipient.to_string(),
-        amount: coins,
-    });
-
-    Ok(Response::new()
-        .add_message(transfer_msg)
-        .add_attribute("action", "callback/send_rewards")
-        .add_attribute("account_id", account_id)
-        .add_attribute("recipient", recipient.to_string()))
+        .add_attribute("rewards", unclaimed_rewards.as_slice().to_string()))
 }

--- a/contracts/credit-manager/src/hls.rs
+++ b/contracts/credit-manager/src/hls.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{Deps, Response};
-use mars_types::{health::AccountKind, params::HlsAssetType};
+use mars_types::{credit_manager::Positions, health::AccountKind, params::HlsAssetType};
 
 use crate::{
     error::{ContractError, ContractResult},
@@ -9,15 +9,24 @@ use crate::{
 
 pub fn assert_hls_rules(deps: Deps, account_id: &str) -> ContractResult<Response> {
     // Rule #1 - There can only be 0 or 1 debt denom in the account
-    let positions = query_positions(deps, account_id)?;
+    let Positions {
+        // destruct Positions so whenever we add new positions we don't forget to add them here
+        account_id,
+        account_kind: _,
+        deposits: _,
+        debts,
+        lends,
+        vaults,
+        staked_astro_lps,
+    } = query_positions(deps, account_id)?;
 
-    if positions.debts.len() > 1 {
+    if debts.len() > 1 {
         return Err(ContractError::HLS {
             reason: "Account has more than one debt denom".to_string(),
         });
     }
 
-    if let Some(debt) = positions.debts.first() {
+    if let Some(debt) = debts.first() {
         let params = PARAMS
             .load(deps.storage)?
             .query_asset_params(&deps.querier, &debt.denom)?
@@ -36,7 +45,7 @@ pub fn assert_hls_rules(deps: Deps, account_id: &str) -> ContractResult<Response
         //          LTV = 0 and won't be considered for HF.
 
         // === Lends ===
-        for lend in positions.lends.iter() {
+        for lend in lends.iter() {
             hls.correlations
                 .iter()
                 .find(|h| match h {
@@ -54,7 +63,7 @@ pub fn assert_hls_rules(deps: Deps, account_id: &str) -> ContractResult<Response
         }
 
         // === Vault positions ===
-        for v in positions.vaults.iter() {
+        for v in vaults.iter() {
             hls.correlations
                 .iter()
                 .find(|h| match h {
@@ -67,6 +76,24 @@ pub fn assert_hls_rules(deps: Deps, account_id: &str) -> ContractResult<Response
                     reason: format!(
                         "{} vault is not a correlated asset to debt {}",
                         v.vault.address, debt.denom
+                    ),
+                })?;
+        }
+
+        // === Staked Astro LP positions ===
+        for staked_astro_lp in staked_astro_lps.iter() {
+            hls.correlations
+                .iter()
+                .find(|h| match h {
+                    HlsAssetType::Coin {
+                        denom,
+                    } => &staked_astro_lp.denom == denom,
+                    _ => false,
+                })
+                .ok_or_else(|| ContractError::HLS {
+                    reason: format!(
+                        "{} staked astro lp is not a correlated asset to debt {}",
+                        staked_astro_lp.denom, debt.denom
                     ),
                 })?;
         }

--- a/contracts/credit-manager/src/hls.rs
+++ b/contracts/credit-manager/src/hls.rs
@@ -30,26 +30,10 @@ pub fn assert_hls_rules(deps: Deps, account_id: &str) -> ContractResult<Response
             });
         };
 
-        // Rule #3: For that debt denom, verify all collateral assets are only those
-        //          within the correlated list for that debt denom
-
-        // === Deposits ===
-        for deposit in positions.deposits.iter() {
-            hls.correlations
-                .iter()
-                .find(|h| match h {
-                    HlsAssetType::Coin {
-                        denom,
-                    } => &deposit.denom == denom,
-                    _ => false,
-                })
-                .ok_or_else(|| ContractError::HLS {
-                    reason: format!(
-                        "{} deposit is not a correlated asset to debt {}",
-                        deposit.denom, debt.denom
-                    ),
-                })?;
-        }
+        // Rule #3: For that debt denom, verify all collateral assets excluding deposits are only those
+        //          within the correlated list for that debt denom.
+        //          Deposits can have claimed rewards which are not correlated. These assets will have
+        //          LTV = 0 and won't be considered for HF.
 
         // === Lends ===
         for lend in positions.lends.iter() {

--- a/contracts/credit-manager/tests/tests/test_claim_rewards.rs
+++ b/contracts/credit-manager/tests/tests/test_claim_rewards.rs
@@ -43,14 +43,17 @@ fn claiming_a_single_reward() {
 
     // Check account id deposit balance
     let positions = mock.query_positions(&account_id);
-    assert_eq!(positions.deposits.len(), 0);
+    assert_eq!(positions.deposits.len(), 1);
+    let reward_coin = get_coin(&coin_info.denom, &positions.deposits);
+    assert_eq!(reward_coin.amount, Uint128::new(123));
 
-    // Ensure money is in user's wallet
+    // Ensure money is in Credit Manager
     let balance = mock.query_balance(&mock.rover, &coin_info.denom);
-    assert_eq!(balance.amount, Uint128::zero());
-
-    let balance = mock.query_balance(&user, &coin_info.denom);
     assert_eq!(balance.amount, Uint128::new(123));
+
+    // Ensure no money is in user's wallet
+    let balance = mock.query_balance(&user, &coin_info.denom);
+    assert_eq!(balance.amount, Uint128::zero());
 }
 
 #[test]
@@ -78,26 +81,29 @@ fn claiming_multiple_rewards() {
 
     // Check account id deposit balance
     let positions = mock.query_positions(&account_id);
-    assert_eq!(positions.deposits.len(), 0);
+    assert_eq!(positions.deposits.len(), 3);
+    let osmo_reward = get_coin(&osmo_info.denom, &positions.deposits);
+    assert_eq!(osmo_reward.amount, Uint128::new(123));
+    let atom_reward = get_coin(&atom_info.denom, &positions.deposits);
+    assert_eq!(atom_reward.amount, Uint128::new(555));
+    let jake_reward = get_coin(&jake_info.denom, &positions.deposits);
+    assert_eq!(jake_reward.amount, Uint128::new(12));
 
-    // Ensure money is in user's wallet
+    // Ensure money is in Credit Manager
     let osmo_balance = mock.query_balance(&mock.rover, &osmo_info.denom);
-    assert_eq!(osmo_balance.amount, Uint128::zero());
-
-    let atom_balance = mock.query_balance(&mock.rover, &atom_info.denom);
-    assert_eq!(atom_balance.amount, Uint128::zero());
-
-    let jake_balance = mock.query_balance(&mock.rover, &jake_info.denom);
-    assert_eq!(jake_balance.amount, Uint128::zero());
-
-    let osmo_balance = mock.query_balance(&user, &osmo_info.denom);
     assert_eq!(osmo_balance.amount, Uint128::new(123));
-
-    let atom_balance = mock.query_balance(&user, &atom_info.denom);
+    let atom_balance = mock.query_balance(&mock.rover, &atom_info.denom);
     assert_eq!(atom_balance.amount, Uint128::new(555));
-
-    let jake_balance = mock.query_balance(&user, &jake_info.denom);
+    let jake_balance = mock.query_balance(&mock.rover, &jake_info.denom);
     assert_eq!(jake_balance.amount, Uint128::new(12));
+
+    // Ensure no money is in user's wallet
+    let osmo_balance = mock.query_balance(&user, &osmo_info.denom);
+    assert_eq!(osmo_balance.amount, Uint128::zero());
+    let atom_balance = mock.query_balance(&user, &atom_info.denom);
+    assert_eq!(atom_balance.amount, Uint128::zero());
+    let jake_balance = mock.query_balance(&user, &jake_info.denom);
+    assert_eq!(jake_balance.amount, Uint128::zero());
 }
 
 #[test]

--- a/contracts/credit-manager/tests/tests/test_claim_rewards.rs
+++ b/contracts/credit-manager/tests/tests/test_claim_rewards.rs
@@ -165,19 +165,25 @@ fn claiming_by_hls_account() {
 
     // Check account id deposit balance
     let positions = mock.query_positions(&account_id);
-    assert_eq!(positions.deposits.len(), 2);
+    assert_eq!(positions.deposits.len(), 4);
     let lp_token_coin = get_coin(&lp_token.denom, &positions.deposits);
     assert_eq!(lp_token_coin.amount, Uint128::new(lp_deposit_amount));
     let atom_coin = get_coin(&atom_info.denom, &positions.deposits);
     assert_eq!(atom_coin.amount, Uint128::new(atom_borrow_amount));
+    let osmo_reward = get_coin(&osmo_info.denom, &positions.deposits);
+    assert_eq!(osmo_reward.amount, Uint128::new(123));
+    let jake_reward = get_coin(&jake_info.denom, &positions.deposits);
+    assert_eq!(jake_reward.amount, Uint128::new(12));
 
-    // Ensure money is in user's wallet
+    // Ensure money is in Credit Manager
     let osmo_balance = mock.query_balance(&mock.rover, &osmo_info.denom);
-    assert_eq!(osmo_balance.amount, Uint128::zero());
-    let jake_balance = mock.query_balance(&mock.rover, &jake_info.denom);
-    assert_eq!(jake_balance.amount, Uint128::zero());
-    let osmo_balance = mock.query_balance(&user, &osmo_info.denom);
     assert_eq!(osmo_balance.amount, Uint128::new(123));
-    let jake_balance = mock.query_balance(&user, &jake_info.denom);
+    let jake_balance = mock.query_balance(&mock.rover, &jake_info.denom);
     assert_eq!(jake_balance.amount, Uint128::new(12));
+
+    // Ensure no money is in user's wallet
+    let osmo_balance = mock.query_balance(&user, &osmo_info.denom);
+    assert_eq!(osmo_balance.amount, Uint128::zero());
+    let jake_balance = mock.query_balance(&user, &jake_info.denom);
+    assert_eq!(jake_balance.amount, Uint128::zero());
 }

--- a/packages/health-computer/src/health_computer.rs
+++ b/packages/health-computer/src/health_computer.rs
@@ -529,7 +529,7 @@ impl HealthComputer {
                     },
                 liquidation_threshold,
                 ..
-            }) = self.coin_contribute_to_collateral(c)?
+            }) = self.coin_contribution_to_collateral(c)?
             else {
                 continue;
             };
@@ -565,7 +565,7 @@ impl HealthComputer {
         })
     }
 
-    fn coin_contribute_to_collateral(&self, coin: &Coin) -> HealthResult<Option<&AssetParams>> {
+    fn coin_contribution_to_collateral(&self, coin: &Coin) -> HealthResult<Option<&AssetParams>> {
         let Some(asset_params) = self.denoms_data.params.get(&coin.denom) else {
             // If the coin is not found (whitelisted), it is not considered for collateral
             return Ok(None);

--- a/packages/health-computer/src/health_computer.rs
+++ b/packages/health-computer/src/health_computer.rs
@@ -529,40 +529,10 @@ impl HealthComputer {
                     },
                 liquidation_threshold,
                 ..
-            }) = self.denoms_data.params.get(&c.denom)
+            }) = self.coin_contribute_to_collateral(c)?
             else {
-                // If the coin is not found (whitelisted), it is not considered for collateral
                 continue;
             };
-
-            match self.kind {
-                AccountKind::HighLeveredStrategy => {
-                    // HLS should have 0 or 1 debt denom in the account
-                    if let Some(debt) = self.positions.debts.first() {
-                        let debt_params = self
-                            .denoms_data
-                            .params
-                            .get(&debt.denom)
-                            .ok_or(MissingParams(debt.denom.clone()))?;
-                        let debt_hls = debt_params
-                            .credit_manager
-                            .hls
-                            .as_ref()
-                            .ok_or(MissingHLSParams(debt.denom.clone()))?;
-                        if !debt_hls.correlations.contains(&HlsAssetType::Coin {
-                            denom: c.denom.clone(),
-                        }) {
-                            continue;
-                        }
-                    } else if hls.is_none() {
-                        continue;
-                    }
-                }
-                AccountKind::Default => {}
-                AccountKind::FundManager {
-                    ..
-                } => {}
-            }
 
             let coin_price =
                 self.denoms_data.prices.get(&c.denom).ok_or(MissingPrice(c.denom.clone()))?;
@@ -593,6 +563,55 @@ impl HealthComputer {
             max_ltv_adjusted_collateral,
             liquidation_threshold_adjusted_collateral,
         })
+    }
+
+    fn coin_contribute_to_collateral(&self, coin: &Coin) -> HealthResult<Option<&AssetParams>> {
+        let Some(asset_params) = self.denoms_data.params.get(&coin.denom) else {
+            // If the coin is not found (whitelisted), it is not considered for collateral
+            return Ok(None);
+        };
+
+        match self.kind {
+            AccountKind::HighLeveredStrategy => {
+                // HLS should have 0 or 1 debt denom in the account. If there are more than 1 we can safely calculate the collateral value
+                // because the rule will be checked in the Credit Manager contract and won't allow more than 1 debt denom in the account.
+                if !self.positions.debts.is_empty() {
+                    let mut correlations = vec![];
+                    for debt in self.positions.debts.iter() {
+                        let debt_params = self
+                            .denoms_data
+                            .params
+                            .get(&debt.denom)
+                            .ok_or(MissingParams(debt.denom.clone()))?;
+                        let debt_hls = debt_params
+                            .credit_manager
+                            .hls
+                            .as_ref()
+                            .ok_or(MissingHLSParams(debt.denom.clone()))?;
+
+                        // collect all the correlations of the debts
+                        correlations.extend(&debt_hls.correlations);
+                    }
+
+                    // If the collateral is not correlated with any of the debts, skip it.
+                    // It doesn't contribute to the collateral value.
+                    if !correlations.contains(&&HlsAssetType::Coin {
+                        denom: coin.denom.clone(),
+                    }) {
+                        return Ok(None);
+                    }
+                } else if asset_params.credit_manager.hls.is_none() {
+                    // Only collateral with hls params can be used in an HLS account and can contribute to the collateral value
+                    return Ok(None);
+                }
+            }
+            AccountKind::Default => {}
+            AccountKind::FundManager {
+                ..
+            } => {}
+        }
+
+        Ok(Some(asset_params))
     }
 
     fn vaults_value(&self) -> HealthResult<CollateralValue> {

--- a/packages/health-computer/tests/tests/helpers/mock_coin_info.rs
+++ b/packages/health-computer/tests/tests/helpers/mock_coin_info.rs
@@ -120,9 +120,15 @@ pub fn ustars_info() -> CoinInfo {
                 hls: Some(HlsParams {
                     max_loan_to_value: Decimal::from_str("0.75").unwrap(),
                     liquidation_threshold: Decimal::from_str("0.8").unwrap(),
-                    correlations: vec![HlsAssetType::Coin {
-                        denom: "stStars".to_string(),
-                    }],
+                    correlations: vec![
+                        HlsAssetType::Coin {
+                            denom: "stStars".to_string(),
+                        },
+                        HlsAssetType::Coin {
+                            // can be also deposited for HLS
+                            denom: "ustars".to_string(),
+                        },
+                    ],
                 }),
             },
             red_bank: RedBankSettings {

--- a/packages/health-computer/tests/tests/helpers/prop_test_runner_borrow.rs
+++ b/packages/health-computer/tests/tests/helpers/prop_test_runner_borrow.rs
@@ -3,7 +3,7 @@ use mars_rover_health_computer::HealthComputer;
 use mars_types::{
     adapters::vault::{CoinValue, VaultPositionValue},
     credit_manager::DebtAmount,
-    health::BorrowTarget,
+    health::{AccountKind, BorrowTarget},
 };
 use proptest::{
     strategy::Strategy,
@@ -77,6 +77,11 @@ fn add_borrow(
     target: &BorrowTarget,
 ) -> StdResult<HealthComputer> {
     let mut new_h = h.clone();
+
+    // HLS can have only 0 or 1 debt
+    if h.kind == AccountKind::HighLeveredStrategy {
+        new_h.positions.debts.clear();
+    }
 
     new_h.positions.debts.push(DebtAmount {
         denom: denom.to_string(),

--- a/packages/health-computer/tests/tests/test_hls.rs
+++ b/packages/health-computer/tests/tests/test_hls.rs
@@ -11,7 +11,7 @@ use mars_types::{
     params::{HlsParams, VaultConfig},
 };
 
-use super::helpers::{udai_info, ustars_info};
+use super::helpers::ustars_info;
 
 #[test]
 fn hls_deposit() {
@@ -72,17 +72,10 @@ fn hls_deposit() {
 #[test]
 fn hls_vault() {
     let ustars = ustars_info();
-    let udai = udai_info();
 
     let denoms_data = DenomsData {
-        prices: HashMap::from([
-            (ustars.denom.clone(), ustars.price),
-            (udai.denom.clone(), udai.price),
-        ]),
-        params: HashMap::from([
-            (ustars.denom.clone(), ustars.params.clone()),
-            (udai.denom.clone(), udai.params.clone()),
-        ]),
+        prices: HashMap::from([(ustars.denom.clone(), ustars.price)]),
+        params: HashMap::from([(ustars.denom.clone(), ustars.params.clone())]),
     };
 
     let vault = Vault::new(Addr::unchecked("vault_addr_123".to_string()));
@@ -126,18 +119,11 @@ fn hls_vault() {
             account_id: "123".to_string(),
             account_kind: AccountKind::HighLeveredStrategy,
             deposits: vec![coin(1200, &ustars.denom)],
-            debts: vec![
-                DebtAmount {
-                    denom: udai.denom,
-                    shares: Default::default(),
-                    amount: Uint128::new(3100),
-                },
-                DebtAmount {
-                    denom: ustars.denom,
-                    shares: Default::default(),
-                    amount: Uint128::new(200),
-                },
-            ],
+            debts: vec![DebtAmount {
+                denom: ustars.denom,
+                shares: Default::default(),
+                amount: Uint128::new(200),
+            }],
             lends: vec![],
             vaults: vec![VaultPosition {
                 vault,
@@ -153,14 +139,14 @@ fn hls_vault() {
     assert_eq!(health.total_collateral_value, Uint128::new(6318574763758));
     assert_eq!(health.max_ltv_adjusted_collateral, Uint128::new(4738931072818));
     assert_eq!(health.liquidation_threshold_adjusted_collateral, Uint128::new(5054859811006));
-    assert_eq!(health.total_debt_value, Uint128::new(1053095794055));
+    assert_eq!(health.total_debt_value, Uint128::new(1053095793083));
     assert_eq!(
         health.max_ltv_health_factor,
-        Some(Decimal::from_str("4.499999999592154861").unwrap())
+        Some(Decimal::from_str("4.500000003745623167").unwrap())
     );
     assert_eq!(
         health.liquidation_health_factor,
-        Some(Decimal::from_str("4.799999999565091796").unwrap())
+        Some(Decimal::from_str("4.800000003995457989").unwrap())
     );
     assert!(!health.is_above_max_ltv());
     assert!(!health.is_liquidatable());
@@ -220,17 +206,10 @@ fn hls_on_blacklisted_asset() {
 #[test]
 fn hls_on_blacklisted_vault() {
     let ustars = ustars_info();
-    let udai = udai_info();
 
     let denoms_data = DenomsData {
-        prices: HashMap::from([
-            (ustars.denom.clone(), ustars.price),
-            (udai.denom.clone(), udai.price),
-        ]),
-        params: HashMap::from([
-            (ustars.denom.clone(), ustars.params.clone()),
-            (udai.denom.clone(), udai.params.clone()),
-        ]),
+        prices: HashMap::from([(ustars.denom.clone(), ustars.price)]),
+        params: HashMap::from([(ustars.denom.clone(), ustars.params.clone())]),
     };
 
     let vault = Vault::new(Addr::unchecked("vault_addr_123".to_string()));
@@ -274,18 +253,11 @@ fn hls_on_blacklisted_vault() {
             account_id: "123".to_string(),
             account_kind: AccountKind::HighLeveredStrategy,
             deposits: vec![coin(1200, &ustars.denom)],
-            debts: vec![
-                DebtAmount {
-                    denom: udai.denom,
-                    shares: Default::default(),
-                    amount: Uint128::new(3100),
-                },
-                DebtAmount {
-                    denom: ustars.denom,
-                    shares: Default::default(),
-                    amount: Uint128::new(200),
-                },
-            ],
+            debts: vec![DebtAmount {
+                denom: ustars.denom,
+                shares: Default::default(),
+                amount: Uint128::new(200),
+            }],
             lends: vec![],
             vaults: vec![VaultPosition {
                 vault,
@@ -301,14 +273,14 @@ fn hls_on_blacklisted_vault() {
     assert_eq!(health.total_collateral_value, Uint128::new(6318574763758));
     assert_eq!(health.max_ltv_adjusted_collateral, Uint128::new(4738931068870));
     assert_eq!(health.liquidation_threshold_adjusted_collateral, Uint128::new(5054859811006));
-    assert_eq!(health.total_debt_value, Uint128::new(1053095794055));
+    assert_eq!(health.total_debt_value, Uint128::new(1053095793083));
     assert_eq!(
         health.max_ltv_health_factor,
-        Some(Decimal::from_str("4.499999995843208163").unwrap())
+        Some(Decimal::from_str("4.499999999996676465").unwrap())
     );
     assert_eq!(
         health.liquidation_health_factor,
-        Some(Decimal::from_str("4.799999999565091796").unwrap())
+        Some(Decimal::from_str("4.800000003995457989").unwrap())
     );
     assert!(!health.is_above_max_ltv());
     assert!(!health.is_liquidatable());

--- a/packages/health-computer/tests/tests/test_max_borrow_validation.rs
+++ b/packages/health-computer/tests/tests/test_max_borrow_validation.rs
@@ -166,17 +166,10 @@ fn cannot_borrow_when_unhealthy() {
 #[test]
 fn hls_influences_max_borrow() {
     let ustars = ustars_info();
-    let udai = udai_info();
 
     let denoms_data = DenomsData {
-        prices: HashMap::from([
-            (ustars.denom.clone(), ustars.price),
-            (udai.denom.clone(), udai.price),
-        ]),
-        params: HashMap::from([
-            (ustars.denom.clone(), ustars.params.clone()),
-            (udai.denom.clone(), udai.params.clone()),
-        ]),
+        prices: HashMap::from([(ustars.denom.clone(), ustars.price)]),
+        params: HashMap::from([(ustars.denom.clone(), ustars.params.clone())]),
     };
 
     let vault = Vault::new(Addr::unchecked("vault_addr_123".to_string()));
@@ -221,18 +214,11 @@ fn hls_influences_max_borrow() {
             account_kind: AccountKind::Default,
 
             deposits: vec![coin(1200, &ustars.denom)],
-            debts: vec![
-                DebtAmount {
-                    denom: udai.denom,
-                    shares: Default::default(),
-                    amount: Uint128::new(3100),
-                },
-                DebtAmount {
-                    denom: ustars.denom.clone(),
-                    shares: Default::default(),
-                    amount: Uint128::new(800),
-                },
-            ],
+            debts: vec![DebtAmount {
+                denom: ustars.denom.clone(),
+                shares: Default::default(),
+                amount: Uint128::new(800),
+            }],
             lends: vec![],
             vaults: vec![VaultPosition {
                 vault,

--- a/packages/health-computer/tests/tests/test_max_swap_validation.rs
+++ b/packages/health-computer/tests/tests/test_max_swap_validation.rs
@@ -358,18 +358,11 @@ fn hls_with_max_withdraw() {
             account_kind: AccountKind::Default,
 
             deposits: vec![coin(1200, &ustars.denom)],
-            debts: vec![
-                DebtAmount {
-                    denom: uatom.denom.clone(),
-                    shares: Default::default(),
-                    amount: Uint128::new(3100),
-                },
-                DebtAmount {
-                    denom: ustars.denom.clone(),
-                    shares: Default::default(),
-                    amount: Uint128::new(800),
-                },
-            ],
+            debts: vec![DebtAmount {
+                denom: ustars.denom.clone(),
+                shares: Default::default(),
+                amount: Uint128::new(800),
+            }],
             lends: vec![],
             vaults: vec![VaultPosition {
                 vault,

--- a/packages/health-computer/tests/tests/test_max_withdraw.rs
+++ b/packages/health-computer/tests/tests/test_max_withdraw.rs
@@ -341,17 +341,10 @@ fn should_allow_max_withdraw() {
 #[test]
 fn hls_with_max_withdraw() {
     let ustars = ustars_info();
-    let udai = udai_info();
 
     let denoms_data = DenomsData {
-        prices: HashMap::from([
-            (ustars.denom.clone(), ustars.price),
-            (udai.denom.clone(), udai.price),
-        ]),
-        params: HashMap::from([
-            (ustars.denom.clone(), ustars.params.clone()),
-            (udai.denom.clone(), udai.params.clone()),
-        ]),
+        prices: HashMap::from([(ustars.denom.clone(), ustars.price)]),
+        params: HashMap::from([(ustars.denom.clone(), ustars.params.clone())]),
     };
 
     let vault = Vault::new(Addr::unchecked("vault_addr_123".to_string()));
@@ -395,18 +388,11 @@ fn hls_with_max_withdraw() {
             account_id: "123".to_string(),
             account_kind: AccountKind::Default,
             deposits: vec![coin(1200, &ustars.denom)],
-            debts: vec![
-                DebtAmount {
-                    denom: udai.denom,
-                    shares: Default::default(),
-                    amount: Uint128::new(3100),
-                },
-                DebtAmount {
-                    denom: ustars.denom.clone(),
-                    shares: Default::default(),
-                    amount: Uint128::new(800),
-                },
-            ],
+            debts: vec![DebtAmount {
+                denom: ustars.denom.clone(),
+                shares: Default::default(),
+                amount: Uint128::new(800),
+            }],
             lends: vec![],
             vaults: vec![VaultPosition {
                 vault,

--- a/packages/types/src/credit_manager/execute.rs
+++ b/packages/types/src/credit_manager/execute.rs
@@ -259,13 +259,9 @@ pub enum CallbackMsg {
         account_id: String,
         coin: ActionCoin,
     },
-    /// Calls incentive contract to claim all rewards and:
-    /// - for Default account increments account balance
-    /// - for HLS account withdraws claimed rewards. HLS accounts have special rules - some assets can't be in the account.
-    /// For simplicity we withdraw all claimed rewards.
+    /// Calls incentive contract to claim all rewards and increment account balance
     ClaimRewards {
         account_id: String,
-        recipient: Addr,
     },
     /// Assert MaxLTV is either:
     /// - Healthy, if prior to actions MaxLTV health factor >= 1 or None
@@ -392,13 +388,6 @@ pub enum CallbackMsg {
     /// At the end of the execution of dispatched actions, this callback removes the guard
     /// and allows subsequent dispatches.
     RemoveReentrancyGuard {},
-    /// Send reward amounts of coin from credit manager to recipient by querying balance, claiming rewards,
-    /// and comparing previous balance to new balance after reward claim - send the diff to the recipient.
-    SendRewardsToAddr {
-        account_id: String,
-        previous_balances: Vec<Coin>,
-        recipient: Addr,
-    },
 }
 
 impl CallbackMsg {

--- a/schemas/mars-credit-manager/mars-credit-manager.json
+++ b/schemas/mars-credit-manager/mars-credit-manager.json
@@ -1118,7 +1118,7 @@
             "additionalProperties": false
           },
           {
-            "description": "Calls incentive contract to claim all rewards and: - for Default account increments account balance - for HLS account withdraws claimed rewards. HLS accounts have special rules - some assets can't be in the account. For simplicity we withdraw all claimed rewards.",
+            "description": "Calls incentive contract to claim all rewards and increment account balance",
             "type": "object",
             "required": [
               "claim_rewards"
@@ -1127,15 +1127,11 @@
               "claim_rewards": {
                 "type": "object",
                 "required": [
-                  "account_id",
-                  "recipient"
+                  "account_id"
                 ],
                 "properties": {
                   "account_id": {
                     "type": "string"
-                  },
-                  "recipient": {
-                    "$ref": "#/definitions/Addr"
                   }
                 },
                 "additionalProperties": false
@@ -1711,39 +1707,6 @@
             "properties": {
               "remove_reentrancy_guard": {
                 "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Send reward amounts of coin from credit manager to recipient by querying balance, claiming rewards, and comparing previous balance to new balance after reward claim - send the diff to the recipient.",
-            "type": "object",
-            "required": [
-              "send_rewards_to_addr"
-            ],
-            "properties": {
-              "send_rewards_to_addr": {
-                "type": "object",
-                "required": [
-                  "account_id",
-                  "previous_balances",
-                  "recipient"
-                ],
-                "properties": {
-                  "account_id": {
-                    "type": "string"
-                  },
-                  "previous_balances": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/Coin"
-                    }
-                  },
-                  "recipient": {
-                    "$ref": "#/definitions/Addr"
-                  }
-                },
                 "additionalProperties": false
               }
             },

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
@@ -281,7 +281,6 @@ export type CallbackMsg =
   | {
       claim_rewards: {
         account_id: string
-        recipient: Addr
       }
     }
   | {
@@ -406,13 +405,6 @@ export type CallbackMsg =
     }
   | {
       remove_reentrancy_guard: {}
-    }
-  | {
-      send_rewards_to_addr: {
-        account_id: string
-        previous_balances: Coin[]
-        recipient: Addr
-      }
     }
 export type Addr = string
 export type HealthState =


### PR DESCRIPTION
- Keep claimed rewards in credit account
- Remove deposits check from HLS rule. It is handled in Health Computer collaterals calculation (see diagram). Only correlated deposits to debt can contribute to collateral value.
- Fix missing `staked_astro_lps` for HLS
- It solves issue for sending rewards to Fund Manager wallet (they are just kept in the account)

High level overview (https://excalidraw.com/#json=zzlhNw1NkvfV8axfJDGl9,Ec_67y7m-_3feub_xC4NSA):
![hls_rules](https://github.com/mars-protocol/contracts/assets/2192395/e6b0770e-643c-48bd-bf66-80af17d001df)
