### PR TITLE
MP-2448. Astro lp deposit cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ name = "mars-params"
 version = "2.0.1"
 dependencies = [
  "anyhow",
+ "astroport 5.0.0-rc.1-tokenfactory",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",

--- a/contracts/credit-manager/src/execute.rs
+++ b/contracts/credit-manager/src/execute.rs
@@ -162,6 +162,7 @@ pub fn dispatch_actions(
     // going up:
     // - Deposit: we check the deposited denom
     // - SwapExactIn: we check the output denom
+    // - ProvideLiquidity: we check the LP token denom
     // - ClaimRewards: we don't check here; the reward amount is likely small so
     //   won't have much impact; this is also difficult to handle given that now
     //   we have multi-rewards

--- a/contracts/credit-manager/src/execute.rs
+++ b/contracts/credit-manager/src/execute.rs
@@ -316,12 +316,17 @@ pub fn dispatch_actions(
                 coins_in,
                 lp_token_out,
                 slippage,
-            } => callbacks.push(CallbackMsg::ProvideLiquidity {
-                account_id: account_id.to_string(),
-                lp_token_out,
-                coins_in,
-                slippage,
-            }),
+            } => {
+                callbacks.push(CallbackMsg::ProvideLiquidity {
+                    account_id: account_id.to_string(),
+                    lp_token_out: lp_token_out.clone(),
+                    coins_in,
+                    slippage,
+                });
+
+                // check the deposit cap of the LP output denom
+                denoms_for_cap_check.insert(lp_token_out);
+            }
             Action::WithdrawLiquidity {
                 lp_token,
                 slippage,

--- a/contracts/credit-manager/tests/tests/test_liquidate_vault.rs
+++ b/contracts/credit-manager/tests/tests/test_liquidate_vault.rs
@@ -68,7 +68,7 @@ fn liquidatee_must_have_the_request_vault_position() {
     assert_err(
         res,
         ContractError::Std(NotFound {
-            kind: "type: mars_types::adapters::vault::amount::VaultPositionAmount; key: [00, 0F, 76, 61, 75, 6C, 74, 5F, 70, 6F, 73, 69, 74, 69, 6F, 6E, 73, 00, 01, 32, 63, 6F, 6E, 74, 72, 61, 63, 74, 31, 30]".to_string(),
+            kind: "type: mars_types::adapters::vault::amount::VaultPositionAmount; key: [00, 0F, 76, 61, 75, 6C, 74, 5F, 70, 6F, 73, 69, 74, 69, 6F, 6E, 73, 00, 01, 32, 63, 6F, 6E, 74, 72, 61, 63, 74, 31, 31]".to_string(),
         }),
     )
 }

--- a/contracts/mock-astroport-incentives/src/contract.rs
+++ b/contracts/mock-astroport-incentives/src/contract.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
 
 use crate::{
     execute::{claim_rewards, deposit, incentivise, withdraw},
-    query::query_rewards,
+    query::{query_deposit, query_rewards},
 };
 #[entry_point]
 pub fn instantiate(
@@ -47,6 +47,10 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             lp_token,
             user,
         } => to_json_binary(&query_rewards(deps, env, user, lp_token)?),
+        QueryMsg::Deposit {
+            lp_token,
+            user,
+        } => to_json_binary(&query_deposit(deps, user, lp_token)?),
         _ => panic!("Unsupported query!"),
     }
 }

--- a/contracts/mock-astroport-incentives/src/query.rs
+++ b/contracts/mock-astroport-incentives/src/query.rs
@@ -37,3 +37,7 @@ pub fn query_rewards(
         None => Ok(vec![]),
     }
 }
+
+pub fn query_deposit(deps: Deps, user: String, lp_token: String) -> StdResult<Uint128> {
+    Ok(ASTRO_LP_INCENTIVE_DEPOSITS.may_load(deps.storage, (&user, &lp_token))?.unwrap_or_default())
+}

--- a/contracts/params/Cargo.toml
+++ b/contracts/params/Cargo.toml
@@ -21,6 +21,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library    = []
 
 [dependencies]
+astroport-v5       = { workspace = true }
 cosmwasm-schema    = { workspace = true }
 cosmwasm-std       = { workspace = true }
 cw2                = { workspace = true }

--- a/contracts/params/src/query.rs
+++ b/contracts/params/src/query.rs
@@ -124,7 +124,7 @@ pub fn query_total_deposit(
     )?;
     let credit_manager_addr = &addresses[&MarsAddressType::CreditManager];
     let red_bank_addr = &addresses[&MarsAddressType::RedBank];
-    let incentives_addr = &addresses[&MarsAddressType::AstroportIncentives];
+    let incentives_addr = &addresses[&MarsAddressType::Incentives];
     let astro_incentives_addr = &addresses[&MarsAddressType::AstroportIncentives];
 
     // amount of this asset deposited into Red Bank

--- a/contracts/params/tests/tests/test_deposit_cap.rs
+++ b/contracts/params/tests/tests/test_deposit_cap.rs
@@ -17,6 +17,8 @@ use super::helpers::default_asset_params;
 
 const CREDIT_MANAGER: &str = "credit_manager";
 const MOCK_DENOM: &str = "utoken";
+const LP_DENOM: &str =
+    "factory/neutron1sf456kx85dz0wfjs4sx0s80dyzmc360pfc0rdzactxt8xrse9ykqsdpy2y/astroport/share";
 const TIMESTAMP: u64 = 1690573960;
 
 #[test_case(
@@ -33,6 +35,7 @@ const TIMESTAMP: u64 = 1690573960;
         amount: Uint128::zero(),
         uncollateralized: true,
     },
+    Uint128::zero(),
     Uint128::zero();
     "zero liquidity, zero debt, zero balance"
 )]
@@ -50,35 +53,62 @@ const TIMESTAMP: u64 = 1690573960;
         amount: Uint128::new(459180188271),
         uncollateralized: true,
     },
-    Uint128::new(1751191642);
+    Uint128::new(1751191642),
+    Uint128::zero();
     "real data queried from mainnet"
 )]
-fn querying_total_deposit(rb_market: Market, rb_debt: UserDebtResponse, cm_balance: Uint128) {
+#[test_case(
+    Market {
+        denom: LP_DENOM.into(),
+        collateral_total_scaled: Uint128::new(6023580722925709342),
+        liquidity_index: Decimal::from_str("1.010435027113017045").unwrap(),
+        indexes_last_updated: 1690573862,
+        ..Default::default()
+    },
+    UserDebtResponse {
+        denom: LP_DENOM.into(),
+        amount_scaled: Uint128::new(442125932248737808),
+        amount: Uint128::new(459180188271),
+        uncollateralized: true,
+    },
+    Uint128::new(1751191642),
+    Uint128::new(1234560000);
+    "real data queried from mainnet with astroport deposit"
+)]
+fn querying_total_deposit(
+    rb_market: Market,
+    rb_debt: UserDebtResponse,
+    cm_balance: Uint128,
+    astroport_deposit: Uint128,
+) {
     let mut deps = mock_dependencies(&[]);
     let env = mock_env_at_block_time(TIMESTAMP);
 
-    let params_unchecked = default_asset_params(MOCK_DENOM);
+    let denom = rb_market.denom.clone();
+
+    let params_unchecked = default_asset_params(&denom);
     let params = params_unchecked.check(deps.as_ref().api).unwrap();
 
     // setup
     deps.querier.set_redbank_market(rb_market.clone());
     deps.querier.set_red_bank_user_debt(CREDIT_MANAGER, rb_debt);
-    deps.querier.update_balances(CREDIT_MANAGER, coins(cm_balance.u128(), MOCK_DENOM));
+    deps.querier.update_balances(CREDIT_MANAGER, coins(cm_balance.u128(), &denom));
+    deps.querier.set_astroport_deposit("incentives", &denom, astroport_deposit);
     ADDRESS_PROVIDER.save(deps.as_mut().storage, &Addr::unchecked("address_provider")).unwrap();
-    ASSET_PARAMS.save(deps.as_mut().storage, MOCK_DENOM, &params).unwrap();
+    ASSET_PARAMS.save(deps.as_mut().storage, &denom, &params).unwrap();
 
     // compute the correct, expected total deposit
     let rb_deposit =
         get_underlying_liquidity_amount(rb_market.collateral_total_scaled, &rb_market, TIMESTAMP)
             .unwrap();
-    let exp_total_deposit = rb_deposit + cm_balance;
+    let exp_total_deposit = rb_deposit + cm_balance + astroport_deposit;
 
     // query total deposit
-    let res = query_total_deposit(deps.as_ref(), &env, MOCK_DENOM.into()).unwrap();
+    let res = query_total_deposit(deps.as_ref(), &env, denom.clone()).unwrap();
     assert_eq!(
         res,
         TotalDepositResponse {
-            denom: MOCK_DENOM.into(),
+            denom,
             amount: exp_total_deposit,
             cap: params.deposit_cap,
         }

--- a/contracts/vault/tests/tests/test_redeem.rs
+++ b/contracts/vault/tests/tests/test_redeem.rs
@@ -74,7 +74,7 @@ fn redeem_invalid_funds() {
     );
     assert_vault_err(
         res,
-        ContractError::Payment(PaymentError::MissingDenom("factory/contract10/vault".to_string())),
+        ContractError::Payment(PaymentError::MissingDenom("factory/contract11/vault".to_string())),
     );
 }
 

--- a/integration-tests/tests/test_oracles.rs
+++ b/integration-tests/tests/test_oracles.rs
@@ -1366,6 +1366,18 @@ fn setup_redbank(wasm: &Wasm<OsmosisTestApp>, signer: &SigningAccount) -> (Strin
     )
     .unwrap();
 
+    // We can simulate Astroport incentives contract deposits with own params address (we don't check deposit caps for Astroport incentives contract so it's safe to use params address here)
+    wasm.execute(
+        &addr_provider_addr,
+        &SetAddress {
+            address_type: MarsAddressType::AstroportIncentives,
+            address: params_addr.clone(),
+        },
+        &[],
+        signer,
+    )
+    .unwrap();
+
     let (market_params, asset_params) = default_asset_params("uosmo");
 
     wasm.execute(

--- a/packages/testing/src/astroport_incentives_querier.rs
+++ b/packages/testing/src/astroport_incentives_querier.rs
@@ -13,7 +13,7 @@ pub struct AstroportIncentivesQuerier {
 impl Default for AstroportIncentivesQuerier {
     fn default() -> Self {
         AstroportIncentivesQuerier {
-            incentives_addr: Addr::unchecked(""),
+            incentives_addr: Addr::unchecked("astroport_incentives"),
             unclaimed_rewards: HashMap::new(),
             deposits: HashMap::new(),
         }

--- a/packages/testing/src/mars_mock_querier.rs
+++ b/packages/testing/src/mars_mock_querier.rs
@@ -108,6 +108,12 @@ impl MarsMockQuerier {
         );
     }
 
+    pub fn set_astroport_deposit(&mut self, user: &str, lp_denom: &str, deposit: Uint128) {
+        self.astroport_incentives_querier
+            .deposits
+            .insert((user.to_string(), lp_denom.to_string()), deposit);
+    }
+
     pub fn set_unclaimed_astroport_lp_rewards(
         &mut self,
         lp_denom: &str,

--- a/packages/testing/src/multitest/helpers/mock_entity_info.rs
+++ b/packages/testing/src/multitest/helpers/mock_entity_info.rs
@@ -6,6 +6,9 @@ use mars_types::params::{HlsAssetType, HlsParamsUnchecked, LiquidationBonus};
 
 use super::{CoinInfo, VaultTestInfo};
 
+pub const ASTRO_LP_DENOM: &str =
+    "factory/neutron1sf456kx85dz0wfjs4sx0s80dyzmc360pfc0rdzactxt8xrse9ykqsdpy2y/astroport/share";
+
 pub fn coin_info(denom: &str) -> CoinInfo {
     CoinInfo {
         denom: denom.to_string(),

--- a/packages/testing/src/multitest/helpers/mock_env.rs
+++ b/packages/testing/src/multitest/helpers/mock_env.rs
@@ -79,7 +79,7 @@ use super::{
     mock_astro_incentives_contract, mock_health_contract, mock_incentives_contract,
     mock_managed_vault_contract, mock_oracle_contract, mock_params_contract,
     mock_red_bank_contract, mock_rover_contract, mock_swapper_contract, mock_v2_zapper_contract,
-    mock_vault_contract, AccountToFund, CoinInfo, VaultTestInfo,
+    mock_vault_contract, AccountToFund, CoinInfo, VaultTestInfo, ASTRO_LP_DENOM,
 };
 use crate::multitest::modules::token_factory::{CustomApp, TokenFactory};
 
@@ -1449,10 +1449,16 @@ impl MockEnvBuilder {
             Addr::unchecked("zapper-instantiator"),
             &ZapperInstantiateMsg {
                 oracle: oracle.clone(),
-                lp_configs: vec![LpConfig {
-                    lp_token_denom: lp_token.denom.to_string(),
-                    lp_pair_denoms: ("uatom".to_string(), "uosmo".to_string()),
-                }],
+                lp_configs: vec![
+                    LpConfig {
+                        lp_token_denom: lp_token.denom.to_string(),
+                        lp_pair_denoms: ("uatom".to_string(), "uosmo".to_string()),
+                    },
+                    LpConfig {
+                        lp_token_denom: ASTRO_LP_DENOM.to_string(),
+                        lp_pair_denoms: ("ujake".to_string(), "uosmo".to_string()),
+                    },
+                ],
             },
             &[],
             "mock-vault",
@@ -1462,7 +1468,7 @@ impl MockEnvBuilder {
         self.app
             .sudo(SudoMsg::Bank(BankSudo::Mint {
                 to_address: addr.to_string(),
-                amount: coins(10_000_000, lp_token.denom),
+                amount: vec![coin(10_000_000, lp_token.denom), coin(10_000_000, ASTRO_LP_DENOM)],
             }))
             .unwrap();
         Ok(ZapperBase::new(addr))

--- a/packages/testing/src/multitest/helpers/mock_env.rs
+++ b/packages/testing/src/multitest/helpers/mock_env.rs
@@ -1090,6 +1090,8 @@ impl MockEnvBuilder {
         let health_contract = self.get_health_contract().into();
         let params = self.get_params_contract().into();
 
+        self.deploy_astroport_incentives();
+
         let addr = self
             .app
             .instantiate_contract(
@@ -1345,12 +1347,15 @@ impl MockEnvBuilder {
             )
             .unwrap();
 
+        self.set_address(MarsAddressType::Incentives, addr.clone());
+
         IncentivesUnchecked::new(addr.to_string())
     }
 
     pub fn deploy_astroport_incentives(&mut self) -> Addr {
         let code_id = self.app.store_code(mock_astro_incentives_contract());
-        self.app
+        let addr = self
+            .app
             .instantiate_contract(
                 code_id,
                 Addr::unchecked("astroport_incentives_owner"),
@@ -1359,7 +1364,11 @@ impl MockEnvBuilder {
                 "mock-astroport-incentives",
                 None,
             )
-            .unwrap()
+            .unwrap();
+
+        self.set_address(MarsAddressType::AstroportIncentives, addr.clone());
+
+        addr
     }
 
     fn deploy_vault(&mut self, vault: &VaultTestInfo) -> Addr {


### PR DESCRIPTION
Add deposit cap check for ProvideLiquidity output LP denom.
It will take into account total LP in CreditManager account + Red Bank deposits + Astroport incentives contract.