### PR TITLE
Zero amounts in Lend and staked_astro_lps

### DIFF
--- a/contracts/credit-manager/src/lend.rs
+++ b/contracts/credit-manager/src/lend.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Coin, Deps, DepsMut, Response, Uint128};
 use mars_types::credit_manager::ActionCoin;
 
 use crate::{
-    error::{ContractError, ContractResult},
+    error::ContractResult,
     state::{COIN_BALANCES, RED_BANK},
     utils::{assert_coin_is_whitelisted, decrement_coin_balance},
 };
@@ -15,29 +15,29 @@ pub fn lend(mut deps: DepsMut, account_id: &str, coin: &ActionCoin) -> ContractR
         amount: get_lend_amount(deps.as_ref(), account_id, coin)?,
     };
 
-    decrement_coin_balance(deps.storage, account_id, &amount_to_lend)?;
+    // Don't error if there is zero amount to lend - just return an empty response
+    let mut res = Response::new();
+    if !amount_to_lend.amount.is_zero() {
+        decrement_coin_balance(deps.storage, account_id, &amount_to_lend)?;
 
-    let red_bank_lend_msg = RED_BANK.load(deps.storage)?.lend_msg(&amount_to_lend, account_id)?;
+        let red_bank_lend_msg =
+            RED_BANK.load(deps.storage)?.lend_msg(&amount_to_lend, account_id)?;
 
-    Ok(Response::new()
-        .add_message(red_bank_lend_msg)
+        res = res.add_message(red_bank_lend_msg);
+    }
+
+    Ok(res
         .add_attribute("action", "lend")
         .add_attribute("account_id", account_id)
         .add_attribute("coin_lent", &amount_to_lend.denom))
 }
 
-/// Queries balance to ensure passing EXACT is not too high.
-/// Also asserts the amount is greater than zero.
+/// Queries balance to ensure passing EXACT is not too high
 fn get_lend_amount(deps: Deps, account_id: &str, coin: &ActionCoin) -> ContractResult<Uint128> {
     let amount_to_lend = if let Some(amount) = coin.amount.value() {
         amount
     } else {
         COIN_BALANCES.may_load(deps.storage, (account_id, &coin.denom))?.unwrap_or(Uint128::zero())
     };
-
-    if amount_to_lend.is_zero() {
-        Err(ContractError::NoAmount)
-    } else {
-        Ok(amount_to_lend)
-    }
+    Ok(amount_to_lend)
 }

--- a/packages/types/src/adapters/incentives.rs
+++ b/packages/types/src/adapters/incentives.rs
@@ -173,7 +173,9 @@ impl Incentives {
             let response =
                 self.query_staked_astro_lp_positions(querier, account_id, start_after, None)?;
             for item in response.data {
-                all_coins.push(item.lp_coin);
+                if !item.lp_coin.amount.is_zero() {
+                    all_coins.push(item.lp_coin);
+                }
             }
             start_after = all_coins.last().map(|item| item.denom.clone());
             has_more = response.metadata.has_more;


### PR DESCRIPTION
- filter out 0 amounts in `staked_astro_lps`
- no error for Lend 0 amount (it would help the FE to be super more flexible for these kind of transactions)