### PR TITLE
MP-2518. Allow to provide min amount for swap

### DIFF
--- a/contracts/credit-manager/src/execute.rs
+++ b/contracts/credit-manager/src/execute.rs
@@ -275,14 +275,14 @@ pub fn dispatch_actions(
             Action::SwapExactIn {
                 coin_in,
                 denom_out,
-                slippage,
+                min_receive,
                 route,
             } => {
                 callbacks.push(CallbackMsg::SwapExactIn {
                     account_id: account_id.to_string(),
                     coin_in,
                     denom_out: denom_out.clone(),
-                    slippage,
+                    min_receive,
                     route,
                 });
                 // check the deposit cap of the swap output denom
@@ -564,9 +564,9 @@ pub fn execute_callback(
             account_id,
             coin_in,
             denom_out,
-            slippage,
+            min_receive,
             route,
-        } => swap_exact_in(deps, env, &account_id, &coin_in, &denom_out, slippage, route),
+        } => swap_exact_in(deps, env, &account_id, &coin_in, &denom_out, min_receive, route),
         CallbackMsg::UpdateCoinBalance {
             account_id,
             previous_balance,

--- a/contracts/credit-manager/src/swap.rs
+++ b/contracts/credit-manager/src/swap.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, Decimal, DepsMut, Env, Response, Uint128};
+use cosmwasm_std::{Coin, DepsMut, Env, Response, Uint128};
 use mars_types::{
     credit_manager::{ActionAmount, ActionCoin, ChangeExpected},
     swapper::SwapperRoute,
@@ -7,7 +7,7 @@ use mars_types::{
 use crate::{
     error::{ContractError, ContractResult},
     state::{COIN_BALANCES, SWAPPER},
-    utils::{assert_slippage, decrement_coin_balance, update_balance_msg},
+    utils::{decrement_coin_balance, update_balance_msg},
 };
 
 pub fn swap_exact_in(
@@ -16,11 +16,9 @@ pub fn swap_exact_in(
     account_id: &str,
     coin_in: &ActionCoin,
     denom_out: &str,
-    slippage: Decimal,
+    min_receive: Uint128,
     route: Option<SwapperRoute>,
 ) -> ContractResult<Response> {
-    assert_slippage(deps.storage, slippage)?;
-
     let coin_in_to_trade = Coin {
         denom: coin_in.denom.clone(),
         amount: match coin_in.amount {
@@ -49,7 +47,7 @@ pub fn swap_exact_in(
     let swapper = SWAPPER.load(deps.storage)?;
 
     Ok(Response::new()
-        .add_message(swapper.swap_exact_in_msg(&coin_in_to_trade, denom_out, slippage, route)?)
+        .add_message(swapper.swap_exact_in_msg(&coin_in_to_trade, denom_out, min_receive, route)?)
         .add_message(update_coin_balance_msg)
         .add_attribute("action", "swapper")
         .add_attribute("account_id", account_id)

--- a/contracts/credit-manager/tests/tests/test_deposit_cap.rs
+++ b/contracts/credit-manager/tests/tests/test_deposit_cap.rs
@@ -58,7 +58,7 @@ use super::helpers::{AccountToFund, MockEnv};
                 amount: ActionAmount::AccountBalance,
             },
             denom_out: "uosmo".into(),
-            slippage: Decimal::percent(5),
+            min_receive: Uint128::zero(),
             route: Some(SwapperRoute::Osmo(OsmoRoute{swaps: vec![
                 OsmoSwap {
                     pool_id: 101,
@@ -85,7 +85,7 @@ use super::helpers::{AccountToFund, MockEnv};
                 amount: ActionAmount::AccountBalance,
             },
             denom_out: "uosmo".into(),
-            slippage: Decimal::percent(5),
+            min_receive: Uint128::zero(),
             route: Some(SwapperRoute::Osmo(OsmoRoute{swaps: vec![
                 OsmoSwap {
                     pool_id: 101,

--- a/contracts/credit-manager/tests/tests/test_swap.rs
+++ b/contracts/credit-manager/tests/tests/test_swap.rs
@@ -1,6 +1,4 @@
-use std::str::FromStr;
-
-use cosmwasm_std::{coins, Addr, Coin, Decimal, OverflowError, OverflowOperation::Sub, Uint128};
+use cosmwasm_std::{coins, Addr, Coin, OverflowError, OverflowOperation::Sub, Uint128};
 use mars_credit_manager::error::ContractError;
 use mars_swapper_mock::contract::MOCK_SWAP_RESULT;
 use mars_types::{
@@ -29,7 +27,7 @@ fn only_token_owner_can_swap_for_account() {
                 amount: ActionAmount::Exact(Uint128::new(12)),
             },
             denom_out: "osmo".to_string(),
-            slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+            min_receive: Uint128::zero(),
             route: Some(SwapperRoute::Osmo(OsmoRoute {
                 swaps: vec![OsmoSwap {
                     pool_id: 101,
@@ -83,7 +81,7 @@ fn denom_out_does_not_have_to_be_whitelisted() {
             SwapExactIn {
                 coin_in: atom_info.to_action_coin(10_000),
                 denom_out: another_coin.denom.clone(),
-                slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+                min_receive: Uint128::zero(),
                 route: Some(route),
             },
         ],
@@ -121,7 +119,7 @@ fn no_amount_sent() {
         vec![SwapExactIn {
             coin_in: osmo_info.to_action_coin(0),
             denom_out: atom_info.denom.clone(),
-            slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+            min_receive: Uint128::zero(),
             route: Some(SwapperRoute::Osmo(OsmoRoute {
                 swaps: vec![OsmoSwap {
                     pool_id: 101,
@@ -151,7 +149,7 @@ fn user_has_zero_balance_for_swap_req() {
         vec![SwapExactIn {
             coin_in: osmo_info.to_action_coin(10_000),
             denom_out: atom_info.denom.clone(),
-            slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+            min_receive: Uint128::zero(),
             route: Some(SwapperRoute::Osmo(OsmoRoute {
                 swaps: vec![OsmoSwap {
                     pool_id: 101,
@@ -169,47 +167,6 @@ fn user_has_zero_balance_for_swap_req() {
             operand1: "0".to_string(),
             operand2: "10000".to_string(),
         }),
-    )
-}
-
-#[test]
-fn slippage_too_high() {
-    let osmo_info = uosmo_info();
-    let atom_info = uatom_info();
-
-    let user = Addr::unchecked("user");
-    let max_slippage = Decimal::percent(50);
-    let mut mock = MockEnv::new()
-        .set_params(&[osmo_info.clone(), atom_info.clone()])
-        .max_slippage(max_slippage)
-        .build()
-        .unwrap();
-    let account_id = mock.create_credit_account(&user).unwrap();
-
-    let slippage = max_slippage + Decimal::from_str("0.000001").unwrap();
-    let res = mock.update_credit_account(
-        &account_id,
-        &user,
-        vec![SwapExactIn {
-            coin_in: osmo_info.to_action_coin(10_000),
-            denom_out: atom_info.denom.clone(),
-            slippage,
-            route: Some(SwapperRoute::Osmo(OsmoRoute {
-                swaps: vec![OsmoSwap {
-                    pool_id: 101,
-                    to: atom_info.denom,
-                }],
-            })),
-        }],
-        &[],
-    );
-
-    assert_err(
-        res,
-        ContractError::SlippageExceeded {
-            slippage,
-            max_slippage,
-        },
     )
 }
 
@@ -237,7 +194,7 @@ fn user_does_not_have_enough_balance_for_swap_req() {
             SwapExactIn {
                 coin_in: osmo_info.to_action_coin(10_000),
                 denom_out: atom_info.denom.clone(),
-                slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+                min_receive: Uint128::zero(),
                 route: Some(SwapperRoute::Osmo(OsmoRoute {
                     swaps: vec![OsmoSwap {
                         pool_id: 101,
@@ -292,7 +249,7 @@ fn swap_success_with_specified_amount() {
             SwapExactIn {
                 coin_in: atom_info.to_action_coin(10_000),
                 denom_out: osmo_info.denom.clone(),
-                slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+                min_receive: MOCK_SWAP_RESULT - Uint128::one(),
                 route: Some(route),
             },
         ],
@@ -346,7 +303,7 @@ fn swap_success_with_amount_none() {
             SwapExactIn {
                 coin_in: atom_info.to_action_coin_full_balance(),
                 denom_out: osmo_info.denom.clone(),
-                slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+                min_receive: MOCK_SWAP_RESULT - Uint128::one(),
                 route: Some(route),
             },
         ],

--- a/contracts/rewards-collector/base/src/error.rs
+++ b/contracts/rewards-collector/base/src/error.rs
@@ -40,6 +40,11 @@ pub enum ContractError {
         reason: String,
     },
 
+    #[error("Invalid min receive: {reason}")]
+    InvalidMinReceive {
+        reason: String,
+    },
+
     #[error("Invalid actions. Only Withdraw and WithdrawLiquidity is possible to pass for CreditManager")]
     InvalidActionsForCreditManager {},
 

--- a/contracts/rewards-collector/osmosis/tests/tests/test_swap.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_swap.rs
@@ -9,7 +9,7 @@ use mars_types::{
 };
 use osmosis_std::types::osmosis::twap::v1beta1::ArithmeticTwapToNowResponse;
 
-use super::{helpers, helpers::mock_instantiate_msg};
+use super::helpers;
 
 #[test]
 fn swapping_asset() {
@@ -67,6 +67,8 @@ fn swapping_asset() {
                     to: cfg.fee_collector_denom.to_string(),
                 }],
             })),
+            safety_fund_min_receive: Some(Uint128::new(1822)),
+            fee_collector_min_receive: Some(Uint128::new(4458)),
         },
     )
     .unwrap();
@@ -78,7 +80,7 @@ fn swapping_asset() {
         msg: to_json_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
             coin_in: coin(safety_fund_input.u128(), "uatom"),
             denom_out: cfg.safety_fund_denom.to_string(),
-            slippage: cfg.slippage_tolerance,
+            min_receive: Uint128::new(1822),
             route: Some(SwapperRoute::Osmo(OsmoRoute {
                 swaps: vec![OsmoSwap {
                     pool_id: 12,
@@ -97,7 +99,7 @@ fn swapping_asset() {
         msg: to_json_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
             coin_in: coin(fee_collector_input.u128(), "uatom"),
             denom_out: cfg.fee_collector_denom.to_string(),
-            slippage: cfg.slippage_tolerance,
+            min_receive: Uint128::new(4458),
             route: Some(SwapperRoute::Osmo(OsmoRoute {
                 swaps: vec![OsmoSwap {
                     pool_id: 69,
@@ -170,6 +172,8 @@ fn skipping_swap_if_denom_matches() {
                     to: "umars".to_string(),
                 }],
             })),
+            safety_fund_min_receive: Some(Uint128::new(1822)),
+            fee_collector_min_receive: Some(Uint128::new(4458)),
         },
     )
     .unwrap();
@@ -194,7 +198,7 @@ fn skipping_swap_if_denom_matches() {
         msg: to_json_binary(&swapper::ExecuteMsg::<Empty, Empty>::SwapExactIn {
             coin_in: coin(926u128, "uusdc"),
             denom_out: "umars".to_string(),
-            slippage: mock_instantiate_msg().slippage_tolerance,
+            min_receive: Uint128::new(4458),
             route: Some(SwapperRoute::Osmo(OsmoRoute {
                 swaps: vec![OsmoSwap {
                     pool_id: 69,

--- a/contracts/swapper/astroport/src/route.rs
+++ b/contracts/swapper/astroport/src/route.rs
@@ -196,10 +196,10 @@ impl Route<Empty, Empty, AstroportConfig> for AstroportRoute {
     /// Build a CosmosMsg that swaps given an input denom and amount
     fn build_exact_in_swap_msg(
         &self,
-        querier: &QuerierWrapper,
+        _querier: &QuerierWrapper,
         _env: &Env,
         coin_in: &Coin,
-        slippage: Decimal,
+        min_receive: Uint128,
     ) -> ContractResult<CosmosMsg> {
         let steps = &self.operations;
 
@@ -207,15 +207,11 @@ impl Route<Empty, Empty, AstroportConfig> for AstroportRoute {
             reason: "the route must contain at least one step".to_string(),
         })?;
 
-        // Calculate the minimum amount of output tokens to receive
-        let out_amount = self.estimate_out_amount(querier, coin_in)?;
-        let minimum_receive = Some((Decimal::one() - slippage) * out_amount);
-
         let swap_msg: CosmosMsg = WasmMsg::Execute {
             contract_addr: self.router.clone(),
             msg: to_json_binary(&astroport_v5::router::ExecuteMsg::ExecuteSwapOperations {
                 operations: self.operations.clone(),
-                minimum_receive,
+                minimum_receive: Some(min_receive),
                 to: None,
                 // If we set max_spread to None, Astroport will unwrap it as 0.5%, so instead we
                 // set it to the max allowed since we control slippage via minimum_receive instead.

--- a/contracts/swapper/base/src/error.rs
+++ b/contracts/swapper/base/src/error.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError, Decimal,
+    CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError,
     DecimalRangeExceeded, OverflowError, StdError,
 };
 use mars_owner::OwnerError;
@@ -49,12 +49,6 @@ pub enum ContractError {
     NoRoute {
         from: String,
         to: String,
-    },
-
-    #[error("Max slippage of {max_slippage} exceeded. Slippage is {slippage}")]
-    MaxSlippageExceeded {
-        max_slippage: Decimal,
-        slippage: Decimal,
     },
 
     #[error("{0}")]

--- a/contracts/swapper/base/src/traits.rs
+++ b/contracts/swapper/base/src/traits.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use cosmwasm_std::{Api, Coin, CosmosMsg, CustomMsg, CustomQuery, Decimal, Env, QuerierWrapper};
+use cosmwasm_std::{Api, Coin, CosmosMsg, CustomMsg, CustomQuery, Env, QuerierWrapper, Uint128};
 use mars_types::swapper::{EstimateExactInSwapResponse, SwapperRoute};
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
@@ -30,7 +30,7 @@ where
         querier: &QuerierWrapper<Q>,
         env: &Env,
         coin_in: &Coin,
-        slippage: Decimal,
+        min_receive: Uint128,
     ) -> ContractResult<CosmosMsg<M>>;
 
     /// Query to get the estimate result of a swap

--- a/contracts/swapper/mock/src/contract.rs
+++ b/contracts/swapper/mock/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coins, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Empty, Env,
+    coins, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env,
     MessageInfo, Response, StdError, StdResult, Uint128,
 };
 use mars_types::swapper::{
@@ -36,9 +36,9 @@ pub fn execute(
         ExecuteMsg::SwapExactIn {
             coin_in,
             denom_out,
-            slippage,
+            min_receive,
             route,
-        } => swap_exact_in(deps, env, info, coin_in, denom_out, slippage, route),
+        } => swap_exact_in(deps, env, info, coin_in, denom_out, min_receive, route),
         ExecuteMsg::UpdateConfig {
             ..
         } => unimplemented!("not implemented"),
@@ -78,7 +78,7 @@ pub fn swap_exact_in(
     info: MessageInfo,
     coin_in: Coin,
     denom_out: String,
-    _slippage: Decimal,
+    _min_receive: Uint128,
     _route: Option<SwapperRoute>,
 ) -> StdResult<Response> {
     let denom_in_balance = deps.querier.query_balance(env.contract.address, coin_in.denom)?;

--- a/contracts/swapper/mock/src/contract.rs
+++ b/contracts/swapper/mock/src/contract.rs
@@ -78,7 +78,7 @@ pub fn swap_exact_in(
     info: MessageInfo,
     coin_in: Coin,
     denom_out: String,
-    _min_receive: Uint128,
+    min_receive: Uint128,
     _route: Option<SwapperRoute>,
 ) -> StdResult<Response> {
     let denom_in_balance = deps.querier.query_balance(env.contract.address, coin_in.denom)?;
@@ -91,6 +91,10 @@ pub fn swap_exact_in(
     } else {
         coin_in.amount
     };
+
+    if transfer_amt < min_receive {
+        return Err(StdError::generic_err("Min amount not reached"));
+    }
 
     // This is dependent on the mock env to pre-fund this contract with uosmo coins
     // simulating a swap has taken place

--- a/contracts/vault/tests/tests/test_performance_fee.rs
+++ b/contracts/vault/tests/tests/test_performance_fee.rs
@@ -513,13 +513,20 @@ fn swap_usdc_to_atom(
             amount: vec![coin(swap_amt.u128(), uatom_info.denom.clone())],
         }))
         .unwrap();
+    let estimate_res = mock.query_swap_estimate_with_optional_route(
+        &uusdc_info.to_coin(swap_amt.u128()),
+        &uatom_info.denom,
+        None,
+    );
+    let min_receive =
+        estimate_res.amount * (Decimal::one() - Decimal::from_atomics(6u128, 1).unwrap());
     mock.update_credit_account(
         fund_acc_id,
         fund_manager,
         vec![Action::SwapExactIn {
             coin_in: uusdc_info.to_action_coin(swap_amt.u128()),
             denom_out: uatom_info.denom.clone(),
-            slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+            min_receive,
             route: None,
         }],
         &[],

--- a/contracts/vault/tests/tests/test_redeem.rs
+++ b/contracts/vault/tests/tests/test_redeem.rs
@@ -401,10 +401,17 @@ fn redeem_succeded(
         actions.push(Action::Lend(uusdc_info.to_action_coin(lend_amt)));
         fund_acc_amt += lend_amt;
     }
+    let estimate_res = mock.query_swap_estimate_with_optional_route(
+        &uusdc_info.to_coin(swap_amt),
+        &uosmo_info.denom,
+        None,
+    );
+    let min_receive =
+        estimate_res.amount * (Decimal::one() - Decimal::from_atomics(6u128, 1).unwrap());
     actions.push(Action::SwapExactIn {
         coin_in: uusdc_info.to_action_coin(swap_amt),
         denom_out: uosmo_info.denom.clone(),
-        slippage: Decimal::from_atomics(6u128, 1).unwrap(),
+        min_receive,
         route: None,
     });
     fund_acc_amt += swap_amt;

--- a/packages/testing/src/astroport_swapper.rs
+++ b/packages/testing/src/astroport_swapper.rs
@@ -1,5 +1,5 @@
 use astroport_v5::router::SwapOperation;
-use cosmwasm_std::{Coin, Decimal, Uint128};
+use cosmwasm_std::{Coin, Uint128};
 #[cfg(feature = "osmosis-test-tube")]
 use cw_it::Artifact;
 use cw_it::{
@@ -181,12 +181,12 @@ impl<'a> AstroportSwapperRobot<'a> {
         &self,
         coin_in: Coin,
         denom_out: impl Into<String>,
-        slippage: Decimal,
+        min_receive: Uint128,
         signer: &SigningAccount,
         route: SwapperRoute,
     ) -> &Self {
         println!("swapping {}", coin_in);
-        self.swap_res(coin_in, denom_out, slippage, signer, route).unwrap();
+        self.swap_res(coin_in, denom_out, min_receive, signer, route).unwrap();
         self
     }
 
@@ -194,7 +194,7 @@ impl<'a> AstroportSwapperRobot<'a> {
         &self,
         coin_in: Coin,
         denom_out: impl Into<String>,
-        slippage: Decimal,
+        min_receive: Uint128,
         signer: &SigningAccount,
         route: SwapperRoute,
     ) -> RunnerExecuteResult<MsgExecuteContractResponse> {
@@ -204,7 +204,7 @@ impl<'a> AstroportSwapperRobot<'a> {
             &mars_types::swapper::ExecuteMsg::<AstroportRoute, AstroportConfig>::SwapExactIn {
                 coin_in: coin_in.clone(),
                 denom_out: denom_out.into(),
-                slippage,
+                min_receive,
                 route: Some(route),
             },
             &[coin_in],

--- a/packages/testing/src/multitest/helpers/mock_env.rs
+++ b/packages/testing/src/multitest/helpers/mock_env.rs
@@ -852,6 +852,15 @@ impl MockEnv {
         denom_out: &str,
         route: SwapperRoute,
     ) -> EstimateExactInSwapResponse {
+        self.query_swap_estimate_with_optional_route(coin_in, denom_out, Some(route))
+    }
+
+    pub fn query_swap_estimate_with_optional_route(
+        &self,
+        coin_in: &Coin,
+        denom_out: &str,
+        route: Option<SwapperRoute>,
+    ) -> EstimateExactInSwapResponse {
         let config = self.query_config();
         self.app
             .wrap()
@@ -860,7 +869,7 @@ impl MockEnv {
                 &EstimateExactInSwap {
                     coin_in: coin_in.clone(),
                     denom_out: denom_out.to_string(),
-                    route: Some(route),
+                    route,
                 },
             )
             .unwrap()

--- a/packages/types/src/adapters/swapper.rs
+++ b/packages/types/src/adapters/swapper.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_json_binary, Addr, Api, Coin, CosmosMsg, Decimal, Empty, StdResult, WasmMsg,
+    to_json_binary, Addr, Api, Coin, CosmosMsg, Empty, StdResult, Uint128, WasmMsg,
 };
 
 use crate::swapper::{ExecuteMsg, SwapperRoute};
@@ -39,7 +39,7 @@ impl Swapper {
         &self,
         coin_in: &Coin,
         denom_out: &str,
-        slippage: Decimal,
+        min_receive: Uint128,
         route: Option<SwapperRoute>,
     ) -> StdResult<CosmosMsg> {
         Ok(CosmosMsg::Wasm(WasmMsg::Execute {
@@ -47,7 +47,7 @@ impl Swapper {
             msg: to_json_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
                 coin_in: coin_in.clone(),
                 denom_out: denom_out.to_string(),
-                slippage,
+                min_receive,
                 route,
             })?,
             funds: vec![coin_in.clone()],
@@ -95,7 +95,7 @@ mod tests {
         let swapper = Swapper::new(Addr::unchecked("swapper"));
         let coin_in = Coin::new(100, "in");
         let denom_out = "out";
-        let slippage = Decimal::percent(1);
+        let min_receive = Uint128::new(123);
 
         let route = SwapperRoute::Osmo(OsmoRoute {
             swaps: vec![
@@ -109,8 +109,9 @@ mod tests {
                 },
             ],
         });
-        let msg =
-            swapper.swap_exact_in_msg(&coin_in, denom_out, slippage, Some(route.clone())).unwrap();
+        let msg = swapper
+            .swap_exact_in_msg(&coin_in, denom_out, min_receive, Some(route.clone()))
+            .unwrap();
         assert_eq!(
             msg,
             CosmosMsg::Wasm(WasmMsg::Execute {
@@ -118,7 +119,7 @@ mod tests {
                 msg: to_json_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
                     coin_in: coin_in.clone(),
                     denom_out: denom_out.to_string(),
-                    slippage,
+                    min_receive,
                     route: Some(route)
                 })
                 .unwrap(),
@@ -138,8 +139,9 @@ mod tests {
                 },
             ],
         });
-        let msg =
-            swapper.swap_exact_in_msg(&coin_in, denom_out, slippage, Some(route.clone())).unwrap();
+        let msg = swapper
+            .swap_exact_in_msg(&coin_in, denom_out, min_receive, Some(route.clone()))
+            .unwrap();
         assert_eq!(
             msg,
             CosmosMsg::Wasm(WasmMsg::Execute {
@@ -147,7 +149,7 @@ mod tests {
                 msg: to_json_binary(&ExecuteMsg::<Empty, Empty>::SwapExactIn {
                     coin_in: coin_in.clone(),
                     denom_out: denom_out.to_string(),
-                    slippage,
+                    min_receive,
                     route: Some(route)
                 })
                 .unwrap(),

--- a/packages/types/src/credit_manager/execute.rs
+++ b/packages/types/src/credit_manager/execute.rs
@@ -185,7 +185,7 @@ pub enum Action {
     SwapExactIn {
         coin_in: ActionCoin,
         denom_out: String,
-        slippage: Decimal,
+        min_receive: Uint128,
         route: Option<SwapperRoute>,
     },
     /// Add Vec<Coin> to liquidity pool in exchange for LP tokens.
@@ -322,7 +322,7 @@ pub enum CallbackMsg {
         account_id: String,
         coin_in: ActionCoin,
         denom_out: String,
-        slippage: Decimal,
+        min_receive: Uint128,
         route: Option<SwapperRoute>,
     },
     /// Used to update the coin balance of account after an async action

--- a/packages/types/src/rewards_collector.rs
+++ b/packages/types/src/rewards_collector.rs
@@ -152,6 +152,8 @@ pub enum ExecuteMsg {
         amount: Option<Uint128>,
         safety_fund_route: Option<SwapperRoute>,
         fee_collector_route: Option<SwapperRoute>,
+        safety_fund_min_receive: Option<Uint128>,
+        fee_collector_min_receive: Option<Uint128>,
     },
 
     /// Claim rewards in incentives contract.

--- a/packages/types/src/swapper.rs
+++ b/packages/types/src/swapper.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Coin, Decimal, Uint128};
+use cosmwasm_std::{Addr, Coin, Uint128};
 use mars_owner::OwnerUpdate;
 
 #[cw_serde]
@@ -56,11 +56,11 @@ pub enum ExecuteMsg<Route, C> {
         denom_out: String,
         route: Route,
     },
-    /// Perform a swapper with an exact-in amount. Requires slippage allowance %.
+    /// Perform a swapper with an exact-in amount
     SwapExactIn {
         coin_in: Coin,
         denom_out: String,
-        slippage: Decimal,
+        min_receive: Uint128,
         route: Option<SwapperRoute>,
     },
     /// Send swapper results back to swapper. Also refunds extra if sent more than needed. Internal use only.

--- a/schemas/mars-credit-manager/mars-credit-manager.json
+++ b/schemas/mars-credit-manager/mars-credit-manager.json
@@ -654,7 +654,7 @@
                 "required": [
                   "coin_in",
                   "denom_out",
-                  "slippage"
+                  "min_receive"
                 ],
                 "properties": {
                   "coin_in": {
@@ -662,6 +662,9 @@
                   },
                   "denom_out": {
                     "type": "string"
+                  },
+                  "min_receive": {
+                    "$ref": "#/definitions/Uint128"
                   },
                   "route": {
                     "anyOf": [
@@ -672,9 +675,6 @@
                         "type": "null"
                       }
                     ]
-                  },
-                  "slippage": {
-                    "$ref": "#/definitions/Decimal"
                   }
                 },
                 "additionalProperties": false
@@ -1396,7 +1396,7 @@
                   "account_id",
                   "coin_in",
                   "denom_out",
-                  "slippage"
+                  "min_receive"
                 ],
                 "properties": {
                   "account_id": {
@@ -1408,6 +1408,9 @@
                   "denom_out": {
                     "type": "string"
                   },
+                  "min_receive": {
+                    "$ref": "#/definitions/Uint128"
+                  },
                   "route": {
                     "anyOf": [
                       {
@@ -1417,9 +1420,6 @@
                         "type": "null"
                       }
                     ]
-                  },
-                  "slippage": {
-                    "$ref": "#/definitions/Decimal"
                   }
                 },
                 "additionalProperties": false

--- a/schemas/mars-rewards-collector-base/mars-rewards-collector-base.json
+++ b/schemas/mars-rewards-collector-base/mars-rewards-collector-base.json
@@ -282,10 +282,30 @@
               "denom": {
                 "type": "string"
               },
+              "fee_collector_min_receive": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Uint128"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "fee_collector_route": {
                 "anyOf": [
                   {
                     "$ref": "#/definitions/SwapperRoute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "safety_fund_min_receive": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Uint128"
                   },
                   {
                     "type": "null"
@@ -644,7 +664,7 @@
                 "required": [
                   "coin_in",
                   "denom_out",
-                  "slippage"
+                  "min_receive"
                 ],
                 "properties": {
                   "coin_in": {
@@ -652,6 +672,9 @@
                   },
                   "denom_out": {
                     "type": "string"
+                  },
+                  "min_receive": {
+                    "$ref": "#/definitions/Uint128"
                   },
                   "route": {
                     "anyOf": [
@@ -662,9 +685,6 @@
                         "type": "null"
                       }
                     ]
-                  },
-                  "slippage": {
-                    "$ref": "#/definitions/Decimal"
                   }
                 },
                 "additionalProperties": false

--- a/schemas/mars-swapper-astroport/mars-swapper-astroport.json
+++ b/schemas/mars-swapper-astroport/mars-swapper-astroport.json
@@ -65,7 +65,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Perform a swapper with an exact-in amount. Requires slippage allowance %.",
+        "description": "Perform a swapper with an exact-in amount",
         "type": "object",
         "required": [
           "swap_exact_in"
@@ -76,7 +76,7 @@
             "required": [
               "coin_in",
               "denom_out",
-              "slippage"
+              "min_receive"
             ],
             "properties": {
               "coin_in": {
@@ -84,6 +84,9 @@
               },
               "denom_out": {
                 "type": "string"
+              },
+              "min_receive": {
+                "$ref": "#/definitions/Uint128"
               },
               "route": {
                 "anyOf": [
@@ -94,9 +97,6 @@
                     "type": "null"
                   }
                 ]
-              },
-              "slippage": {
-                "$ref": "#/definitions/Decimal"
               }
             },
             "additionalProperties": false
@@ -312,10 +312,6 @@
             "type": "string"
           }
         }
-      },
-      "Decimal": {
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-        "type": "string"
       },
       "OsmoRoute": {
         "type": "object",

--- a/schemas/mars-swapper-base/mars-swapper-base.json
+++ b/schemas/mars-swapper-base/mars-swapper-base.json
@@ -65,7 +65,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Perform a swapper with an exact-in amount. Requires slippage allowance %.",
+        "description": "Perform a swapper with an exact-in amount",
         "type": "object",
         "required": [
           "swap_exact_in"
@@ -76,7 +76,7 @@
             "required": [
               "coin_in",
               "denom_out",
-              "slippage"
+              "min_receive"
             ],
             "properties": {
               "coin_in": {
@@ -84,6 +84,9 @@
               },
               "denom_out": {
                 "type": "string"
+              },
+              "min_receive": {
+                "$ref": "#/definitions/Uint128"
               },
               "route": {
                 "anyOf": [
@@ -94,9 +97,6 @@
                     "type": "null"
                   }
                 ]
-              },
-              "slippage": {
-                "$ref": "#/definitions/Decimal"
               }
             },
             "additionalProperties": false
@@ -209,10 +209,6 @@
             "type": "string"
           }
         }
-      },
-      "Decimal": {
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-        "type": "string"
       },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",

--- a/schemas/mars-swapper-osmosis/mars-swapper-osmosis.json
+++ b/schemas/mars-swapper-osmosis/mars-swapper-osmosis.json
@@ -65,7 +65,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Perform a swapper with an exact-in amount. Requires slippage allowance %.",
+        "description": "Perform a swapper with an exact-in amount",
         "type": "object",
         "required": [
           "swap_exact_in"
@@ -76,7 +76,7 @@
             "required": [
               "coin_in",
               "denom_out",
-              "slippage"
+              "min_receive"
             ],
             "properties": {
               "coin_in": {
@@ -84,6 +84,9 @@
               },
               "denom_out": {
                 "type": "string"
+              },
+              "min_receive": {
+                "$ref": "#/definitions/Uint128"
               },
               "route": {
                 "anyOf": [
@@ -94,9 +97,6 @@
                     "type": "null"
                   }
                 ]
-              },
-              "slippage": {
-                "$ref": "#/definitions/Decimal"
               }
             },
             "additionalProperties": false
@@ -209,10 +209,6 @@
             "type": "string"
           }
         }
-      },
-      "Decimal": {
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-        "type": "string"
       },
       "OsmoRoute": {
         "type": "object",

--- a/scripts/deploy/base/test-actions-credit-manager.ts
+++ b/scripts/deploy/base/test-actions-credit-manager.ts
@@ -146,7 +146,7 @@ export class Rover {
         swap_exact_in: {
           coin_in: { amount: { exact: amount }, denom: this.config.chain.baseDenom },
           denom_out: this.actions.secondaryDenom,
-          slippage: this.actions.swap.slippage,
+          min_receive: '0',
         },
       },
     ])

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
@@ -138,8 +138,8 @@ export type Action =
       swap_exact_in: {
         coin_in: ActionCoin
         denom_out: string
+        min_receive: Uint128
         route?: SwapperRoute | null
-        slippage: Decimal
       }
     }
   | {
@@ -342,8 +342,8 @@ export type CallbackMsg =
         account_id: string
         coin_in: ActionCoin
         denom_out: string
+        min_receive: Uint128
         route?: SwapperRoute | null
-        slippage: Decimal
       }
     }
   | {

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.client.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.client.ts
@@ -110,12 +110,16 @@ export interface MarsRewardsCollectorBaseInterface
     {
       amount,
       denom,
+      feeCollectorMinReceive,
       feeCollectorRoute,
+      safetyFundMinReceive,
       safetyFundRoute,
     }: {
       amount?: Uint128
       denom: string
+      feeCollectorMinReceive?: Uint128
       feeCollectorRoute?: SwapperRoute
+      safetyFundMinReceive?: Uint128
       safetyFundRoute?: SwapperRoute
     },
     fee?: number | StdFee | 'auto',
@@ -279,12 +283,16 @@ export class MarsRewardsCollectorBaseClient
     {
       amount,
       denom,
+      feeCollectorMinReceive,
       feeCollectorRoute,
+      safetyFundMinReceive,
       safetyFundRoute,
     }: {
       amount?: Uint128
       denom: string
+      feeCollectorMinReceive?: Uint128
       feeCollectorRoute?: SwapperRoute
+      safetyFundMinReceive?: Uint128
       safetyFundRoute?: SwapperRoute
     },
     fee: number | StdFee | 'auto' = 'auto',
@@ -298,7 +306,9 @@ export class MarsRewardsCollectorBaseClient
         swap_asset: {
           amount,
           denom,
+          fee_collector_min_receive: feeCollectorMinReceive,
           fee_collector_route: feeCollectorRoute,
+          safety_fund_min_receive: safetyFundMinReceive,
           safety_fund_route: safetyFundRoute,
         },
       },

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.react-query.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.react-query.ts
@@ -111,7 +111,9 @@ export interface MarsRewardsCollectorBaseSwapAssetMutation {
   msg: {
     amount?: Uint128
     denom: string
+    feeCollectorMinReceive?: Uint128
     feeCollectorRoute?: SwapperRoute
+    safetyFundMinReceive?: Uint128
     safetyFundRoute?: SwapperRoute
   }
   args?: {

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.types.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.types.ts
@@ -59,7 +59,9 @@ export type ExecuteMsg =
       swap_asset: {
         amount?: Uint128 | null
         denom: string
+        fee_collector_min_receive?: Uint128 | null
         fee_collector_route?: SwapperRoute | null
+        safety_fund_min_receive?: Uint128 | null
         safety_fund_route?: SwapperRoute | null
       }
     }
@@ -151,8 +153,8 @@ export type Action =
       swap_exact_in: {
         coin_in: ActionCoin
         denom_out: string
+        min_receive: Uint128
         route?: SwapperRoute | null
-        slippage: Decimal
       }
     }
   | {

--- a/scripts/types/generated/mars-swapper-astroport/MarsSwapperAstroport.client.ts
+++ b/scripts/types/generated/mars-swapper-astroport/MarsSwapperAstroport.client.ts
@@ -16,7 +16,6 @@ import {
   Addr,
   Uint128,
   SwapperRoute,
-  Decimal,
   AstroportRoute,
   Coin,
   AstroRoute,
@@ -154,13 +153,13 @@ export interface MarsSwapperAstroportInterface extends MarsSwapperAstroportReadO
     {
       coinIn,
       denomOut,
+      minReceive,
       route,
-      slippage,
     }: {
       coinIn: Coin
       denomOut: string
+      minReceive: Uint128
       route?: SwapperRoute
-      slippage: Decimal
     },
     fee?: number | StdFee | 'auto',
     memo?: string,
@@ -259,13 +258,13 @@ export class MarsSwapperAstroportClient
     {
       coinIn,
       denomOut,
+      minReceive,
       route,
-      slippage,
     }: {
       coinIn: Coin
       denomOut: string
+      minReceive: Uint128
       route?: SwapperRoute
-      slippage: Decimal
     },
     fee: number | StdFee | 'auto' = 'auto',
     memo?: string,
@@ -278,8 +277,8 @@ export class MarsSwapperAstroportClient
         swap_exact_in: {
           coin_in: coinIn,
           denom_out: denomOut,
+          min_receive: minReceive,
           route,
-          slippage,
         },
       },
       fee,

--- a/scripts/types/generated/mars-swapper-astroport/MarsSwapperAstroport.react-query.ts
+++ b/scripts/types/generated/mars-swapper-astroport/MarsSwapperAstroport.react-query.ts
@@ -17,7 +17,6 @@ import {
   Addr,
   Uint128,
   SwapperRoute,
-  Decimal,
   AstroportRoute,
   Coin,
   AstroRoute,
@@ -263,8 +262,8 @@ export interface MarsSwapperAstroportSwapExactInMutation {
   msg: {
     coinIn: Coin
     denomOut: string
+    minReceive: Uint128
     route?: SwapperRoute
-    slippage: Decimal
   }
   args?: {
     fee?: number | StdFee | 'auto'

--- a/scripts/types/generated/mars-swapper-astroport/MarsSwapperAstroport.types.ts
+++ b/scripts/types/generated/mars-swapper-astroport/MarsSwapperAstroport.types.ts
@@ -23,8 +23,8 @@ export type ExecuteMsg =
       swap_exact_in: {
         coin_in: Coin
         denom_out: string
+        min_receive: Uint128
         route?: SwapperRoute | null
-        slippage: Decimal
       }
     }
   | {
@@ -87,7 +87,6 @@ export type SwapperRoute =
   | {
       osmo: OsmoRoute
     }
-export type Decimal = string
 export interface AstroportRoute {
   factory: string
   operations: SwapOperation[]

--- a/scripts/types/generated/mars-swapper-base/MarsSwapperBase.client.ts
+++ b/scripts/types/generated/mars-swapper-base/MarsSwapperBase.client.ts
@@ -13,7 +13,6 @@ import {
   OwnerUpdate,
   Uint128,
   SwapperRoute,
-  Decimal,
   Addr,
   Empty,
   Coin,
@@ -150,13 +149,13 @@ export interface MarsSwapperBaseInterface extends MarsSwapperBaseReadOnlyInterfa
     {
       coinIn,
       denomOut,
+      minReceive,
       route,
-      slippage,
     }: {
       coinIn: Coin
       denomOut: string
+      minReceive: Uint128
       route?: SwapperRoute
-      slippage: Decimal
     },
     fee?: number | StdFee | 'auto',
     memo?: string,
@@ -255,13 +254,13 @@ export class MarsSwapperBaseClient
     {
       coinIn,
       denomOut,
+      minReceive,
       route,
-      slippage,
     }: {
       coinIn: Coin
       denomOut: string
+      minReceive: Uint128
       route?: SwapperRoute
-      slippage: Decimal
     },
     fee: number | StdFee | 'auto' = 'auto',
     memo?: string,
@@ -274,8 +273,8 @@ export class MarsSwapperBaseClient
         swap_exact_in: {
           coin_in: coinIn,
           denom_out: denomOut,
+          min_receive: minReceive,
           route,
-          slippage,
         },
       },
       fee,

--- a/scripts/types/generated/mars-swapper-base/MarsSwapperBase.react-query.ts
+++ b/scripts/types/generated/mars-swapper-base/MarsSwapperBase.react-query.ts
@@ -14,7 +14,6 @@ import {
   OwnerUpdate,
   Uint128,
   SwapperRoute,
-  Decimal,
   Addr,
   Empty,
   Coin,
@@ -258,8 +257,8 @@ export interface MarsSwapperBaseSwapExactInMutation {
   msg: {
     coinIn: Coin
     denomOut: string
+    minReceive: Uint128
     route?: SwapperRoute
-    slippage: Decimal
   }
   args?: {
     fee?: number | StdFee | 'auto'

--- a/scripts/types/generated/mars-swapper-base/MarsSwapperBase.types.ts
+++ b/scripts/types/generated/mars-swapper-base/MarsSwapperBase.types.ts
@@ -23,8 +23,8 @@ export type ExecuteMsg =
       swap_exact_in: {
         coin_in: Coin
         denom_out: string
+        min_receive: Uint128
         route?: SwapperRoute | null
-        slippage: Decimal
       }
     }
   | {
@@ -62,7 +62,6 @@ export type SwapperRoute =
   | {
       osmo: OsmoRoute
     }
-export type Decimal = string
 export type Addr = string
 export interface Empty {
   [k: string]: unknown

--- a/scripts/types/generated/mars-swapper-osmosis/MarsSwapperOsmosis.client.ts
+++ b/scripts/types/generated/mars-swapper-osmosis/MarsSwapperOsmosis.client.ts
@@ -14,7 +14,6 @@ import {
   OsmosisRoute,
   Uint128,
   SwapperRoute,
-  Decimal,
   Addr,
   SwapAmountInRoute,
   Coin,
@@ -153,13 +152,13 @@ export interface MarsSwapperOsmosisInterface extends MarsSwapperOsmosisReadOnlyI
     {
       coinIn,
       denomOut,
+      minReceive,
       route,
-      slippage,
     }: {
       coinIn: Coin
       denomOut: string
+      minReceive: Uint128
       route?: SwapperRoute
-      slippage: Decimal
     },
     fee?: number | StdFee | 'auto',
     memo?: string,
@@ -258,13 +257,13 @@ export class MarsSwapperOsmosisClient
     {
       coinIn,
       denomOut,
+      minReceive,
       route,
-      slippage,
     }: {
       coinIn: Coin
       denomOut: string
+      minReceive: Uint128
       route?: SwapperRoute
-      slippage: Decimal
     },
     fee: number | StdFee | 'auto' = 'auto',
     memo?: string,
@@ -277,8 +276,8 @@ export class MarsSwapperOsmosisClient
         swap_exact_in: {
           coin_in: coinIn,
           denom_out: denomOut,
+          min_receive: minReceive,
           route,
-          slippage,
         },
       },
       fee,

--- a/scripts/types/generated/mars-swapper-osmosis/MarsSwapperOsmosis.react-query.ts
+++ b/scripts/types/generated/mars-swapper-osmosis/MarsSwapperOsmosis.react-query.ts
@@ -15,7 +15,6 @@ import {
   OsmosisRoute,
   Uint128,
   SwapperRoute,
-  Decimal,
   Addr,
   SwapAmountInRoute,
   Coin,
@@ -264,8 +263,8 @@ export interface MarsSwapperOsmosisSwapExactInMutation {
   msg: {
     coinIn: Coin
     denomOut: string
+    minReceive: Uint128
     route?: SwapperRoute
-    slippage: Decimal
   }
   args?: {
     fee?: number | StdFee | 'auto'

--- a/scripts/types/generated/mars-swapper-osmosis/MarsSwapperOsmosis.types.ts
+++ b/scripts/types/generated/mars-swapper-osmosis/MarsSwapperOsmosis.types.ts
@@ -23,8 +23,8 @@ export type ExecuteMsg =
       swap_exact_in: {
         coin_in: Coin
         denom_out: string
+        min_receive: Uint128
         route?: SwapperRoute | null
-        slippage: Decimal
       }
     }
   | {
@@ -63,7 +63,6 @@ export type SwapperRoute =
   | {
       osmo: OsmoRoute
     }
-export type Decimal = string
 export type Addr = string
 export interface SwapAmountInRoute {
   pool_id: number


### PR DESCRIPTION
We used TWAP and oracle prices to prevent pool manipulation. However, since we can now trade any assets (https://github.com/mars-protocol/contracts/pull/381), we don't have a reliable price source to calculate the `min_amount` in the smart contract (SC).
If we use a simulation request on Astro, the user won't know how much they will receive. By calculating it outside of the smart contract and displaying it to the user, they will know the exact amount they will receive.

**This is braking change**

`Swap` action on credit manager:
```diff
SwapExactIn {
    coin_in: ActionCoin,
    denom_out: String,
-   slippage: Decimal,
+   min_receive: Uint128,
    route: Option<SwapperRoute>,
}
```
`SwapAsset` on rewards-collector:
```diff
SwapAsset {
    denom: String,
    amount: Option<Uint128>,
    safety_fund_route: Option<SwapperRoute>,
    fee_collector_route: Option<SwapperRoute>,
+   safety_fund_min_receive: Option<Uint128>,
+   fee_collector_min_receive: Option<Uint128>,
}
```