### PR TITLE
CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,7 +319,7 @@ type UserCollateralsResponse = {
 type UserCollateralsResponse = UserCollateralResponse[];
 ```
 
-- ([#61](https://github.com/mars-protocol/red-bank/pull/61)) Red Bank: Implement variable naming convension.
+- ([#61](https://github.com/mars-protocol/red-bank/pull/61)) Red Bank: Implement variable naming convention.
 
 ```diff
 pub struct CreateOrUpdateConfig {


### PR DESCRIPTION
### Title
Fix typo in `CHANGELOG.md`

### Description
This pull request fixes a minor typo in `CHANGELOG.md`. The word "convension" has been corrected to "convention."

### Details of Changes
- Corrected "convension" to "convention" in `CHANGELOG.md`.

### Checklist
- [x] Typos have been corrected.
- [x] The document was proofread for additional errors.

### Additional Notes
This fix ensures consistency and professionalism in the documentation.
